### PR TITLE
Card 読み取り API とサービス層導入

### DIFF
--- a/backend/src/main/java/com/example/taskmanagement/card/CardController.java
+++ b/backend/src/main/java/com/example/taskmanagement/card/CardController.java
@@ -4,9 +4,11 @@ import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -15,29 +17,28 @@ import java.util.List;
 @RequestMapping("/api/cards")
 public class CardController {
 
-    private final CardRepository repository;
+    private final CardService service;
 
-    public CardController(CardRepository repository) {
-        this.repository = repository;
+    public CardController(CardService service) {
+        this.service = service;
     }
 
     @GetMapping
-    public List<Card> list() {
-        return repository.findAllByOrderByColumnIdAscOrderIndexAsc();
+    public List<Card> list(@RequestParam(required = false) String columnId) {
+        if (columnId != null && !columnId.isBlank()) {
+            return service.findByColumn(columnId);
+        }
+        return service.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public Card get(@PathVariable String id) {
+        return service.findById(id);
     }
 
     @PostMapping
     public ResponseEntity<Card> create(@Valid @RequestBody CardCreateRequest request) {
-        Card card = new Card();
-        card.setTitle(request.title());
-        card.setDescription(request.description());
-        if (request.priority() != null) {
-            card.setPriority(request.priority());
-        }
-        card.setDueDate(request.dueDate());
-        card.setColumnId(request.columnId());
-        card.setOrderIndex(request.orderIndex());
-        Card saved = repository.save(card);
+        Card saved = service.create(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(saved);
     }
 }

--- a/backend/src/main/java/com/example/taskmanagement/card/CardNotFoundException.java
+++ b/backend/src/main/java/com/example/taskmanagement/card/CardNotFoundException.java
@@ -1,0 +1,11 @@
+package com.example.taskmanagement.card;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class CardNotFoundException extends RuntimeException {
+    public CardNotFoundException(String id) {
+        super("Card not found: " + id);
+    }
+}

--- a/backend/src/main/java/com/example/taskmanagement/card/CardRepository.java
+++ b/backend/src/main/java/com/example/taskmanagement/card/CardRepository.java
@@ -6,4 +6,6 @@ import java.util.List;
 
 public interface CardRepository extends JpaRepository<Card, String> {
     List<Card> findAllByOrderByColumnIdAscOrderIndexAsc();
+
+    List<Card> findByColumnIdOrderByOrderIndexAsc(String columnId);
 }

--- a/backend/src/main/java/com/example/taskmanagement/card/CardService.java
+++ b/backend/src/main/java/com/example/taskmanagement/card/CardService.java
@@ -1,0 +1,46 @@
+package com.example.taskmanagement.card;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class CardService {
+
+    private final CardRepository repository;
+
+    public CardService(CardRepository repository) {
+        this.repository = repository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<Card> findAll() {
+        return repository.findAllByOrderByColumnIdAscOrderIndexAsc();
+    }
+
+    @Transactional(readOnly = true)
+    public List<Card> findByColumn(String columnId) {
+        return repository.findByColumnIdOrderByOrderIndexAsc(columnId);
+    }
+
+    @Transactional(readOnly = true)
+    public Card findById(String id) {
+        return repository.findById(id)
+                .orElseThrow(() -> new CardNotFoundException(id));
+    }
+
+    public Card create(CardCreateRequest request) {
+        Card card = new Card();
+        card.setTitle(request.title());
+        card.setDescription(request.description());
+        if (request.priority() != null) {
+            card.setPriority(request.priority());
+        }
+        card.setDueDate(request.dueDate());
+        card.setColumnId(request.columnId());
+        card.setOrderIndex(request.orderIndex());
+        return repository.save(card);
+    }
+}

--- a/backend/src/main/resources/db/migration/V2__seed_cards.sql
+++ b/backend/src/main/resources/db/migration/V2__seed_cards.sql
@@ -1,0 +1,10 @@
+INSERT INTO cards (id, title, description, priority, due_date, column_id, order_index)
+VALUES
+    ('11111111-1111-1111-1111-111111111101', '要件定義レビュー', 'ステークホルダーと要件をすり合わせる', 'high',   '2026-05-10', 'todo',        1),
+    ('11111111-1111-1111-1111-111111111102', 'ER図ドラフト作成', 'cards テーブル拡張案を検討',         'medium', '2026-05-12', 'todo',        2),
+    ('11111111-1111-1111-1111-111111111103', '環境構築手順の整備', 'README に compose 起動手順を追記', 'low',    NULL,         'todo',        3),
+    ('22222222-2222-2222-2222-222222222201', 'Read API 実装',     'GET /api/cards/{id} を追加',         'high',   '2026-04-30', 'doing', 1),
+    ('22222222-2222-2222-2222-222222222202', 'サービス層リファクタ', 'Controller→Service→Repository に整える', 'medium', '2026-04-30', 'doing', 2),
+    ('33333333-3333-3333-3333-333333333301', 'リポジトリ初期セットアップ', 'Spring Boot 雛形と Hello World', 'medium', NULL, 'done', 1),
+    ('33333333-3333-3333-3333-333333333302', 'Card Create API',   'POST /api/cards 実装',               'medium', NULL,         'done',        2)
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## Summary
- `GET /api/cards/{id}` を追加 (見つからない場合は 404)
- `GET /api/cards?columnId=xxx` の絞り込みクエリを追加
- `CardService` / `CardNotFoundException` を新規追加し、Controller→Service→Repository の三層構成に整理
- Flyway V2 で動作確認用のシードデータ (todo / doing / done) を投入

## Test plan
- [x] `docker compose up -d db` で PostgreSQL 起動
- [x] `./gradlew bootRun` で起動 (Flyway V2 適用成功)
- [x] `GET /api/cards` で seed 全件取得
- [x] `GET /api/cards?columnId=todo` で todo 列のみ返却
- [x] `GET /api/cards/<seed-uuid>` で単一取得 200
- [x] `GET /api/cards/not-exist` で 404

Closes #4