### PR TITLE
docs: 技術スタックにバージョン追記し README を整備 (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,83 @@
 # TaskManagement
 
-タスク管理アプリの開発リポジトリ（AI Engineer Course 課題）。
+Trello 風のカンバン方式で個人のタスクを管理する Web アプリケーション。AI Engineer Course の学習課題として、要件定義から実装までの一連の開発プロセスを経験することを目的に開発している。
 
-## 構成
+「未着手 / 作業中 / 完了」の 3 カラムで個人のタスクを視覚的に管理する、単一ユーザー前提・認証なしの SPA。
 
-- `backend/` — Spring Boot 4.0 + Java 25 (REST API)
-- `frontend/` — React + TypeScript + Vite + Tailwind CSS
-- `compose.yaml` — PostgreSQL（ローカル開発用）
+## 目次
 
-## ローカル起動
+- [プロジェクト構成](#プロジェクト構成)
+- [技術スタック](#技術スタック)
+- [ローカル開発環境のセットアップ](#ローカル開発環境のセットアップ)
+- [ポート運用ルール](#ポート運用ルール)
+- [ドキュメント一覧](#ドキュメント一覧)
+- [開発フロー](#開発フロー)
 
-### 1. データベース
+## プロジェクト構成
+
+```
+TaskManagement/
+├── backend/        Spring Boot 4.0 + Java 25 (REST API)
+├── frontend/       React 19 + TypeScript + Vite + Tailwind CSS (SPA)
+├── compose.yaml    PostgreSQL 16 (ローカル開発用)
+├── docs/           設計・要件ドキュメント
+├── mocks/          モックデータ / 画面モック
+├── 要件定義書.md    要件定義のエントリポイント
+├── CLAUDE.md       Claude Code 用の運用ルール
+└── README.md
+```
+
+## 技術スタック
+
+主要なバージョンの抜粋。詳細は [docs/tech-stack.md](docs/tech-stack.md) を参照。
+
+### フロントエンド
+
+- React 19.2 / React DOM 19.2
+- TypeScript 6.0
+- Vite 8.0
+- Tailwind CSS 4.2
+- Axios 1.15
+- ESLint 9 / Prettier 3
+
+### バックエンド
+
+- Java 25 (LTS)
+- Spring Boot 4.0.0
+- Spring Data JPA (Hibernate)
+- Flyway
+- Gradle 9.3.1 (Kotlin DSL, Wrapper 同梱)
+
+### データベース / インフラ
+
+- PostgreSQL 16 (Docker Compose)
+
+## ローカル開発環境のセットアップ
+
+### 前提
+
+- Java 25 (Gradle Toolchain により自動取得される場合あり)
+- Node.js (Vite 8 / React 19 が動作するバージョン)
+- Docker Desktop（Compose v2）
+
+### 1. データベース起動 (port 5432)
 
 ```bash
 docker compose up -d
 ```
 
-### 2. バックエンド (port 8080)
+`taskmanagement` データベースが `task_user` / `task_pass` で作成される。スキーマは Flyway がバックエンド起動時に適用する。
+
+### 2. バックエンド起動 (port 8080)
 
 ```bash
 cd backend
 ./gradlew bootRun
 ```
 
-### 3. フロントエンド (port 5173)
+REST API が `http://localhost:8080` で待ち受ける。
+
+### 3. フロントエンド起動 (port 5173)
 
 ```bash
 cd frontend
@@ -31,5 +85,57 @@ npm install
 npm run dev
 ```
 
-ブラウザで <http://localhost:5173> を開く。
-Vite dev server が `/api` を `http://localhost:8080` にプロキシするため CORS 設定は不要。
+ブラウザで <http://localhost:5173> を開く。Vite dev server が `/api` を `http://localhost:8080` にプロキシするため、CORS 設定は不要。
+
+### 主要コマンド
+
+| 場所 | コマンド | 用途 |
+|---|---|---|
+| `frontend/` | `npm run dev` | 開発サーバ起動 |
+| `frontend/` | `npm run build` | 型チェック + プロダクションビルド |
+| `frontend/` | `npm run lint` | ESLint 実行 |
+| `frontend/` | `npm run format` | Prettier 整形 |
+| `backend/` | `./gradlew bootRun` | アプリ起動 |
+| `backend/` | `./gradlew test` | テスト実行 |
+| `backend/` | `./gradlew build` | ビルド |
+| ルート | `docker compose up -d` | PostgreSQL 起動 |
+| ルート | `docker compose down` | PostgreSQL 停止 |
+
+## ポート運用ルール
+
+このプロジェクトで使用するポートは以下に固定する。**別ポートでの代替起動は禁止**（プロキシ設定や URL 前提が崩れて動作確認にならないため）。
+
+| サービス | ポート |
+|---|---|
+| フロントエンド (Vite) | 5173 |
+| バックエンド (Spring Boot) | 8080 |
+| PostgreSQL | 5432 |
+
+ポートが競合した場合は、`lsof -i :<port>` で占有プロセスを特定して停止し、本来のポートで起動し直す。詳細は [CLAUDE.md](CLAUDE.md#ポート運用ルール厳守) を参照。
+
+## ドキュメント一覧
+
+| 種別 | ドキュメント |
+|---|---|
+| 要件定義のエントリポイント | [要件定義書.md](要件定義書.md) |
+| ユースケース / 操作フロー | [docs/use-cases.md](docs/use-cases.md) |
+| 機能要件 | [docs/functional-requirements.md](docs/functional-requirements.md) |
+| 画面設計・画面遷移 | [docs/screen-design.md](docs/screen-design.md) |
+| ER 図 / DB 設計 | [docs/er-diagram.md](docs/er-diagram.md) |
+| データフロー / API | [docs/data-flow.md](docs/data-flow.md) |
+| 非機能要件 | [docs/non-functional-requirements.md](docs/non-functional-requirements.md) |
+| 技術スタック | [docs/tech-stack.md](docs/tech-stack.md) |
+| 対象外機能（スコープ外） | [docs/out-of-scope.md](docs/out-of-scope.md) |
+| 運用ルール (Claude Code 用) | [CLAUDE.md](CLAUDE.md) |
+
+## 開発フロー
+
+`main` への直接 push は禁止。すべて Issue → ブランチ → PR の流れで進める。
+
+1. GitHub の Issue テンプレート（Feature / Bug / Task / Docs）から Issue を起票
+2. `<type>/#<issue>-<slug>` 形式（例: `feat/#12-add-login-form`）でブランチを作成
+3. 変更をコミット・push
+4. PR を作成し、本文に `Closes #<issue>` を含める
+5. レビューコメントを全解決した上で squash / rebase でマージ
+
+詳細なルール（ブランチ命名、PR 規約、main ブランチ保護設定）は [CLAUDE.md](CLAUDE.md) を参照。

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -1,25 +1,52 @@
 # 技術スタック
 
-| 分類 | 採用技術 |
-|---|---|
-| フロントエンド | React + TypeScript（Next.js は使用しない） |
-| ビルドツール (FE) | Vite |
-| ドラッグ＆ドロップ | @dnd-kit/core |
-| スタイリング | Tailwind CSS |
-| HTTPクライアント | Axios |
-| Lint / Format (FE) | ESLint + Prettier |
-| テスト (FE) | Vitest + React Testing Library |
-| バックエンド | Java 25 (LTS) + Spring Boot 4.0.x |
-| API 形式 | REST（spring-boot-starter-web） |
-| バリデーション | spring-boot-starter-validation (Jakarta Bean Validation) |
-| ORM | Spring Data JPA (Hibernate) |
-| DB マイグレーション | Flyway |
-| DB | PostgreSQL 16 |
-| ビルドツール (BE) | Gradle (Kotlin DSL) |
-| テスト (BE) | JUnit 5 + Spring Boot Test + Testcontainers (PostgreSQL) |
-| ローカル実行環境 | Docker Compose（PostgreSQL を起動） |
+環境構築済みの技術と、確定しているバージョンを記載する。「(未導入)」と付記したものは要件として採用予定だが、本リポジトリにはまだ導入されていない。
+
+## フロントエンド
+
+| 分類 | 採用技術 | バージョン |
+|---|---|---|
+| 言語 | TypeScript | 6.0.x |
+| UI ライブラリ | React / React DOM | 19.2.x |
+| ビルドツール | Vite | 8.0.x |
+| Vite プラグイン | @vitejs/plugin-react | 6.0.x |
+| スタイリング | Tailwind CSS / @tailwindcss/vite | 4.2.x |
+| HTTP クライアント | Axios | 1.15.x |
+| Lint | ESLint | 9.14.x |
+| Lint (TS) | @typescript-eslint/eslint-plugin / parser | 8.59.x |
+| Lint (React) | eslint-plugin-react-hooks / react-refresh | 7.1.x / 0.5.x |
+| Format | Prettier | 3.3.x |
+| ドラッグ＆ドロップ | @dnd-kit/core | (未導入) |
+| テスト | Vitest + React Testing Library | (未導入) |
+
+> Next.js は使用しない（SPA 構成）。
+
+## バックエンド
+
+| 分類 | 採用技術 | バージョン |
+|---|---|---|
+| 言語 | Java (LTS) | 25 |
+| フレームワーク | Spring Boot | 4.0.0 |
+| ビルドツール | Gradle (Kotlin DSL) | 9.3.1 (Wrapper 同梱) |
+| 依存管理プラグイン | io.spring.dependency-management | 1.1.7 |
+| Web | spring-boot-starter-web | (Boot 4.0.0 に追従) |
+| バリデーション | spring-boot-starter-validation (Jakarta Bean Validation) | (Boot 4.0.0 に追従) |
+| ORM | Spring Data JPA (Hibernate) | (Boot 4.0.0 に追従) |
+| DB マイグレーション | Flyway (spring-boot-flyway / flyway-database-postgresql) | (Boot 4.0.0 に追従) |
+| JDBC ドライバ | org.postgresql:postgresql | (Boot 4.0.0 に追従) |
+| テスト | JUnit 5 + Spring Boot Test | (Boot 4.0.0 に追従) |
+| 結合テスト | Testcontainers (PostgreSQL) | (未導入) |
+
+## インフラ / ローカル実行
+
+| 分類 | 採用技術 | バージョン |
+|---|---|---|
+| RDB | PostgreSQL | 16 (alpine) |
+| ローカル実行環境 | Docker Compose | — |
 
 ## 補足
-- Java は 2025年9月リリースの最新 LTS である Java 25 を採用。Spring Boot は 2025年11月 GA の最新メジャー 4.0.x を採用。
-- DB アクセスのテストは Testcontainers により実 PostgreSQL を立ち上げて検証する。
+
+- Java は 2025 年 9 月リリースの最新 LTS である Java 25 を採用。Spring Boot は 2025 年 11 月 GA の最新メジャー 4.0.x を採用。
+- React / Vite / Tailwind / TypeScript は本リポジトリで採用時点の最新メジャーに揃えている（React 19 / Vite 8 / Tailwind 4 / TypeScript 6）。
 - マイグレーションは Spring Boot との親和性から Flyway を採用。
+- DB アクセスのテストは Testcontainers により実 PostgreSQL を立ち上げて検証する方針（導入予定）。


### PR DESCRIPTION
## Summary
- `docs/tech-stack.md` に採用済み技術の確定バージョンを追記し、未導入のものを明記
- `README.md` を再構成し、プロジェクト構成・技術スタック・セットアップ・ポート運用・ドキュメント一覧・開発フローを整備

Closes #10

## Test plan
- [x] README のリンクが切れていないことを目視確認
- [x] tech-stack のバージョン記載が `package.json` / `build.gradle.kts` と整合

🤖 Generated with [Claude Code](https://claude.com/claude-code)