### PR TITLE
feat: カード新規作成フォームを追加

### DIFF
--- a/frontend/src/api/cards.ts
+++ b/frontend/src/api/cards.ts
@@ -1,9 +1,23 @@
 import { apiClient } from './client';
-import type { Card, ColumnId } from '../types/card';
+import type { Card, ColumnId, Priority } from '../types/card';
 
 export async function fetchCards(columnId?: ColumnId): Promise<Card[]> {
   const res = await apiClient.get<Card[]>('/cards', {
     params: columnId ? { columnId } : undefined,
   });
+  return res.data;
+}
+
+export interface CardCreateInput {
+  title: string;
+  columnId: ColumnId;
+  orderIndex: number;
+  description?: string;
+  priority?: Priority;
+  dueDate?: string | null;
+}
+
+export async function createCard(input: CardCreateInput): Promise<Card> {
+  const res = await apiClient.post<Card>('/cards', input);
   return res.data;
 }

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { fetchCards } from '../api/cards';
+import { createCard, fetchCards, type CardCreateInput } from '../api/cards';
 import { COLUMNS, type Card, type ColumnId } from '../types/card';
 import Column from './Column';
 
@@ -34,6 +34,28 @@ export default function Board() {
     };
   }, []);
 
+  const handleCreate = async (
+    columnId: ColumnId,
+    input: Omit<CardCreateInput, 'columnId' | 'orderIndex'>,
+  ) => {
+    try {
+      const created = await createCard({
+        ...input,
+        columnId,
+        orderIndex: data[columnId].length,
+      });
+      setData((prev) => ({
+        ...prev,
+        [columnId]: [...prev[columnId], created],
+      }));
+      setError(null);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'カードの登録に失敗しました';
+      setError(msg);
+      throw e instanceof Error ? e : new Error(msg);
+    }
+  };
+
   if (loading) {
     return <p className="text-sm text-gray-500">読み込み中…</p>;
   }
@@ -47,7 +69,13 @@ export default function Board() {
       )}
       <div className="flex gap-4 overflow-x-auto">
         {COLUMNS.map((c) => (
-          <Column key={c.id} label={c.label} cards={data[c.id]} />
+          <Column
+            key={c.id}
+            columnId={c.id}
+            label={c.label}
+            cards={data[c.id]}
+            onCreate={handleCreate}
+          />
         ))}
       </div>
     </div>

--- a/frontend/src/components/CardCreateForm.tsx
+++ b/frontend/src/components/CardCreateForm.tsx
@@ -1,0 +1,122 @@
+import { useState, type FormEvent } from 'react';
+import type { CardCreateInput } from '../api/cards';
+import type { ColumnId, Priority } from '../types/card';
+
+interface Props {
+  columnId: ColumnId;
+  onSubmit: (input: Omit<CardCreateInput, 'columnId' | 'orderIndex'>) => Promise<void>;
+  onCancel: () => void;
+}
+
+const PRIORITY_OPTIONS: { value: Priority; label: string }[] = [
+  { value: 'high', label: '高' },
+  { value: 'medium', label: '中' },
+  { value: 'low', label: '低' },
+];
+
+export default function CardCreateForm({ onSubmit, onCancel }: Props) {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [priority, setPriority] = useState<Priority>('medium');
+  const [dueDate, setDueDate] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    const trimmed = title.trim();
+    if (!trimmed) {
+      setError('タイトルは必須です');
+      return;
+    }
+    if (trimmed.length > 100) {
+      setError('タイトルは100文字以内で入力してください');
+      return;
+    }
+    if (description.length > 1000) {
+      setError('説明は1000文字以内で入力してください');
+      return;
+    }
+    setError(null);
+    setSubmitting(true);
+    try {
+      await onSubmit({
+        title: trimmed,
+        description: description.trim() ? description : undefined,
+        priority,
+        dueDate: dueDate ? dueDate : null,
+      });
+      setTitle('');
+      setDescription('');
+      setPriority('medium');
+      setDueDate('');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '登録に失敗しました');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex flex-col gap-2 rounded-md border border-gray-200 bg-white p-2 shadow-sm"
+    >
+      <input
+        type="text"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="タイトル (必須)"
+        maxLength={100}
+        required
+        autoFocus
+        className="rounded border border-gray-300 px-2 py-1 text-sm"
+      />
+      <textarea
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        placeholder="説明 (任意)"
+        maxLength={1000}
+        rows={2}
+        className="resize-y rounded border border-gray-300 px-2 py-1 text-sm"
+      />
+      <div className="flex gap-2">
+        <select
+          value={priority}
+          onChange={(e) => setPriority(e.target.value as Priority)}
+          className="flex-1 rounded border border-gray-300 px-2 py-1 text-sm"
+        >
+          {PRIORITY_OPTIONS.map((p) => (
+            <option key={p.value} value={p.value}>
+              {p.label}
+            </option>
+          ))}
+        </select>
+        <input
+          type="date"
+          value={dueDate}
+          onChange={(e) => setDueDate(e.target.value)}
+          className="flex-1 rounded border border-gray-300 px-2 py-1 text-sm"
+        />
+      </div>
+      {error && <p className="text-xs text-red-600">{error}</p>}
+      <div className="flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={submitting}
+          className="rounded px-3 py-1 text-xs text-gray-600 hover:bg-gray-100 disabled:opacity-50"
+        >
+          キャンセル
+        </button>
+        <button
+          type="submit"
+          disabled={submitting}
+          className="rounded bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {submitting ? '登録中…' : '登録'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/components/Column.tsx
+++ b/frontend/src/components/Column.tsx
@@ -1,24 +1,57 @@
-import type { Card } from '../types/card';
+import { useState } from 'react';
+import type { CardCreateInput } from '../api/cards';
+import type { Card, ColumnId } from '../types/card';
 import CardItem from './CardItem';
+import CardCreateForm from './CardCreateForm';
 
 interface Props {
+  columnId: ColumnId;
   label: string;
   cards: Card[];
+  onCreate: (
+    columnId: ColumnId,
+    input: Omit<CardCreateInput, 'columnId' | 'orderIndex'>,
+  ) => Promise<void>;
 }
 
-export default function Column({ label, cards }: Props) {
+export default function Column({ columnId, label, cards, onCreate }: Props) {
+  const [adding, setAdding] = useState(false);
+
+  const handleSubmit = async (
+    input: Omit<CardCreateInput, 'columnId' | 'orderIndex'>,
+  ) => {
+    await onCreate(columnId, input);
+    setAdding(false);
+  };
+
   return (
     <section className="flex w-80 flex-shrink-0 flex-col rounded-lg bg-gray-100 p-3">
       <header className="mb-3 flex items-center justify-between px-1">
         <h2 className="text-sm font-semibold text-gray-700">
           {label} <span className="ml-1 text-gray-500">({cards.length})</span>
         </h2>
+        {!adding && (
+          <button
+            type="button"
+            onClick={() => setAdding(true)}
+            className="rounded px-2 py-1 text-xs text-gray-600 hover:bg-gray-200"
+          >
+            ＋ 追加
+          </button>
+        )}
       </header>
       <div className="flex flex-col gap-2">
-        {cards.length === 0 ? (
+        {cards.length === 0 && !adding ? (
           <p className="py-6 text-center text-sm text-gray-400">カードがありません</p>
         ) : (
           cards.map((c) => <CardItem key={c.id} card={c} />)
+        )}
+        {adding && (
+          <CardCreateForm
+            columnId={columnId}
+            onSubmit={handleSubmit}
+            onCancel={() => setAdding(false)}
+          />
         )}
       </div>
     </section>


### PR DESCRIPTION
## 概要
- フロントからカードを新規登録できる UI を追加
- `createCard` API クライアント / `CardCreateForm` 新規 / `Column` ヘッダーに追加ボタン / `Board` で作成後の即時反映
- 優先度ドロップダウンは日本語表記 (高 / 中 / 低)

## 動作確認
- [x] `npm run build` (tsc -b + vite build) 成功
- [x] `POST /api/cards` 正常系 201, 必須未入力で 400
- [x] ブラウザから各カラムへ登録 → 即時反映 / リロード後も DB 永続化

Closes #12