### PR TITLE
feat: カード編集機能 (タイトル/説明/優先度/期日)

### DIFF
--- a/backend/src/main/java/com/example/taskmanagement/card/CardController.java
+++ b/backend/src/main/java/com/example/taskmanagement/card/CardController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -40,5 +41,10 @@ public class CardController {
     public ResponseEntity<Card> create(@Valid @RequestBody CardCreateRequest request) {
         Card saved = service.create(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(saved);
+    }
+
+    @PutMapping("/{id}")
+    public Card updateContent(@PathVariable String id, @Valid @RequestBody UpdateCardContentRequest request) {
+        return service.updateContent(id, request);
     }
 }

--- a/backend/src/main/java/com/example/taskmanagement/card/CardService.java
+++ b/backend/src/main/java/com/example/taskmanagement/card/CardService.java
@@ -31,6 +31,16 @@ public class CardService {
                 .orElseThrow(() -> new CardNotFoundException(id));
     }
 
+    public Card updateContent(String id, UpdateCardContentRequest request) {
+        Card card = repository.findById(id)
+                .orElseThrow(() -> new CardNotFoundException(id));
+        card.setTitle(request.title());
+        card.setDescription(request.description());
+        card.setPriority(request.priority());
+        card.setDueDate(request.dueDate());
+        return repository.save(card);
+    }
+
     public Card create(CardCreateRequest request) {
         Card card = new Card();
         card.setTitle(request.title());

--- a/backend/src/main/java/com/example/taskmanagement/card/UpdateCardContentRequest.java
+++ b/backend/src/main/java/com/example/taskmanagement/card/UpdateCardContentRequest.java
@@ -1,0 +1,14 @@
+package com.example.taskmanagement.card;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+
+public record UpdateCardContentRequest(
+        @NotBlank @Size(max = 100) String title,
+        @Size(max = 1000) String description,
+        @NotBlank @Pattern(regexp = "high|medium|low") String priority,
+        LocalDate dueDate
+) {}

--- a/frontend/src/api/cards.ts
+++ b/frontend/src/api/cards.ts
@@ -21,3 +21,18 @@ export async function createCard(input: CardCreateInput): Promise<Card> {
   const res = await apiClient.post<Card>('/cards', input);
   return res.data;
 }
+
+export interface UpdateCardContentInput {
+  title: string;
+  description: string;
+  priority: Priority;
+  dueDate: string | null;
+}
+
+export async function updateCardContent(
+  id: string,
+  input: UpdateCardContentInput,
+): Promise<Card> {
+  const res = await apiClient.put<Card>(`/cards/${id}`, input);
+  return res.data;
+}

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { createCard, fetchCards, type CardCreateInput } from '../api/cards';
 import { COLUMNS, type Card, type ColumnId } from '../types/card';
+import CardEditModal from './CardEditModal';
 import Column from './Column';
 
 type CardsByColumn = Record<ColumnId, Card[]>;
@@ -11,6 +12,16 @@ export default function Board() {
   const [data, setData] = useState<CardsByColumn>(EMPTY);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [editing, setEditing] = useState<Card | null>(null);
+
+  const handleCardSaved = (updated: Card) => {
+    setData((prev) => ({
+      ...prev,
+      [updated.columnId]: prev[updated.columnId]
+        .map((c) => (c.id === updated.id ? updated : c))
+        .sort((a, b) => a.orderIndex - b.orderIndex),
+    }));
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -75,9 +86,17 @@ export default function Board() {
             label={c.label}
             cards={data[c.id]}
             onCreate={handleCreate}
+            onCardClick={setEditing}
           />
         ))}
       </div>
+      {editing && (
+        <CardEditModal
+          card={editing}
+          onClose={() => setEditing(null)}
+          onSaved={handleCardSaved}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/CardEditModal.tsx
+++ b/frontend/src/components/CardEditModal.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from 'react';
+import { updateCardContent } from '../api/cards';
+import type { Card, Priority } from '../types/card';
+
+const PRIORITY_OPTIONS: { value: Priority; label: string }[] = [
+  { value: 'high', label: '高' },
+  { value: 'medium', label: '中' },
+  { value: 'low', label: '低' },
+];
+
+interface Props {
+  card: Card;
+  onClose: () => void;
+  onSaved: (card: Card) => void;
+}
+
+export default function CardEditModal({ card, onClose, onSaved }: Props) {
+  const [title, setTitle] = useState(card.title);
+  const [description, setDescription] = useState(card.description ?? '');
+  const [priority, setPriority] = useState<Priority>(card.priority);
+  const [dueDate, setDueDate] = useState<string>(card.dueDate ?? '');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) {
+      setError('タイトルは必須です');
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const updated = await updateCardContent(card.id, {
+        title: title.trim(),
+        description,
+        priority,
+        dueDate: dueDate ? dueDate : null,
+      });
+      onSaved(updated);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '更新に失敗しました');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-md rounded-lg bg-white p-5 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="mb-4 text-base font-semibold text-gray-900">カードを編集</h2>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="text-gray-700">タイトル</span>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              maxLength={100}
+              className="rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none"
+              autoFocus
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="text-gray-700">説明</span>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              maxLength={1000}
+              rows={5}
+              className="rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none"
+            />
+          </label>
+          <div className="flex gap-3">
+            <label className="flex flex-1 flex-col gap-1 text-sm">
+              <span className="text-gray-700">優先度</span>
+              <select
+                value={priority}
+                onChange={(e) => setPriority(e.target.value as Priority)}
+                className="rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none"
+              >
+                {PRIORITY_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex flex-1 flex-col gap-1 text-sm">
+              <span className="text-gray-700">期日</span>
+              <input
+                type="date"
+                value={dueDate}
+                onChange={(e) => setDueDate(e.target.value)}
+                className="rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none"
+              />
+            </label>
+          </div>
+          {error && (
+            <p className="rounded border border-red-200 bg-red-50 p-2 text-xs text-red-700">
+              {error}
+            </p>
+          )}
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded border border-gray-300 px-3 py-1 text-sm text-gray-700 hover:bg-gray-50"
+              disabled={submitting}
+            >
+              キャンセル
+            </button>
+            <button
+              type="submit"
+              className="rounded bg-blue-600 px-3 py-1 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+              disabled={submitting}
+            >
+              {submitting ? '保存中…' : '保存'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/CardItem.tsx
+++ b/frontend/src/components/CardItem.tsx
@@ -9,9 +9,17 @@ function isOverdue(dueDate: string): boolean {
   return due < today;
 }
 
-export default function CardItem({ card }: { card: Card }) {
+interface Props {
+  card: Card;
+  onClick?: (card: Card) => void;
+}
+
+export default function CardItem({ card, onClick }: Props) {
   return (
-    <article className="rounded-md border border-gray-200 bg-white p-3 shadow-sm">
+    <article
+      className="cursor-pointer rounded-md border border-gray-200 bg-white p-3 shadow-sm hover:border-blue-300 hover:shadow"
+      onClick={() => onClick?.(card)}
+    >
       <h3 className="mb-2 text-sm font-medium text-gray-900">{card.title}</h3>
       <div className="flex items-center justify-between">
         <PriorityBadge priority={card.priority} />

--- a/frontend/src/components/Column.tsx
+++ b/frontend/src/components/Column.tsx
@@ -12,9 +12,10 @@ interface Props {
     columnId: ColumnId,
     input: Omit<CardCreateInput, 'columnId' | 'orderIndex'>,
   ) => Promise<void>;
+  onCardClick?: (card: Card) => void;
 }
 
-export default function Column({ columnId, label, cards, onCreate }: Props) {
+export default function Column({ columnId, label, cards, onCreate, onCardClick }: Props) {
   const [adding, setAdding] = useState(false);
 
   const handleSubmit = async (
@@ -44,7 +45,7 @@ export default function Column({ columnId, label, cards, onCreate }: Props) {
         {cards.length === 0 && !adding ? (
           <p className="py-6 text-center text-sm text-gray-400">カードがありません</p>
         ) : (
-          cards.map((c) => <CardItem key={c.id} card={c} />)
+          cards.map((c) => <CardItem key={c.id} card={c} onClick={onCardClick} />)
         )}
         {adding && (
           <CardCreateForm


### PR DESCRIPTION
## Summary
- `PUT /api/cards/{id}` を追加し、カードのタイトル・説明・優先度・期日を更新できるようにした
- フロント側に編集モーダル (`CardEditModal`) を追加し、カードクリックで開いて保存後はボード表示が即時更新される

## 変更内容
### バックエンド
- `UpdateCardContentRequest` (新規): title 必須・priority は high/medium/low のみ・dueDate は任意
- `CardService.updateContent` 追加（`@PreUpdate` で updatedAt 自動更新）
- `CardController` に PUT エンドポイント追加

### フロントエンド
- `api/cards.ts` に `updateCardContent` を追加
- `CardEditModal.tsx` 新規（タイトル / 説明 / 優先度セレクト / 期日ピッカー、ESC・背景クリックで閉じる）
- `CardItem` をクリック可能化、`Board` で選択中カードを管理し保存後 state を更新

## Test plan
- [x] curl で正常系・空 title (400) ・存在しない id (404) ・不正な priority (400) を確認
- [x] ブラウザで編集モーダルからの保存が即時反映されることを確認
- [x] フロント tsc / バックエンド compileJava 通過

Closes #16