### PR TITLE
feat: カード移動・並び替え (DnD + 並び替えボタン)

### DIFF
--- a/backend/src/main/java/com/example/taskmanagement/card/CardController.java
+++ b/backend/src/main/java/com/example/taskmanagement/card/CardController.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -46,5 +47,10 @@ public class CardController {
     @PutMapping("/{id}")
     public Card updateContent(@PathVariable String id, @Valid @RequestBody UpdateCardContentRequest request) {
         return service.updateContent(id, request);
+    }
+
+    @PatchMapping("/{id}/position")
+    public Card updatePosition(@PathVariable String id, @Valid @RequestBody UpdateCardPositionRequest request) {
+        return service.updatePosition(id, request);
     }
 }

--- a/backend/src/main/java/com/example/taskmanagement/card/CardService.java
+++ b/backend/src/main/java/com/example/taskmanagement/card/CardService.java
@@ -31,6 +31,55 @@ public class CardService {
                 .orElseThrow(() -> new CardNotFoundException(id));
     }
 
+    public Card updatePosition(String id, UpdateCardPositionRequest request) {
+        Card card = repository.findById(id)
+                .orElseThrow(() -> new CardNotFoundException(id));
+
+        String fromColumnId = card.getColumnId();
+        String toColumnId = request.columnId();
+        int targetIndex = request.orderIndex();
+
+        if (fromColumnId.equals(toColumnId)) {
+            List<Card> siblings = repository.findByColumnIdOrderByOrderIndexAsc(toColumnId).stream()
+                    .filter(c -> !c.getId().equals(id))
+                    .collect(java.util.stream.Collectors.toList());
+            int insertAt = Math.min(targetIndex, siblings.size());
+            siblings.add(insertAt, card);
+            for (int i = 0; i < siblings.size(); i++) {
+                Card c = siblings.get(i);
+                if (c.getOrderIndex() == null || c.getOrderIndex() != i) {
+                    c.setOrderIndex(i);
+                    repository.save(c);
+                }
+            }
+            return card;
+        }
+
+        List<Card> fromSiblings = repository.findByColumnIdOrderByOrderIndexAsc(fromColumnId).stream()
+                .filter(c -> !c.getId().equals(id))
+                .collect(java.util.stream.Collectors.toList());
+        for (int i = 0; i < fromSiblings.size(); i++) {
+            Card c = fromSiblings.get(i);
+            if (c.getOrderIndex() == null || c.getOrderIndex() != i) {
+                c.setOrderIndex(i);
+                repository.save(c);
+            }
+        }
+
+        List<Card> toSiblings = repository.findByColumnIdOrderByOrderIndexAsc(toColumnId);
+        int insertAt = Math.min(targetIndex, toSiblings.size());
+        card.setColumnId(toColumnId);
+        toSiblings.add(insertAt, card);
+        for (int i = 0; i < toSiblings.size(); i++) {
+            Card c = toSiblings.get(i);
+            if (c.getOrderIndex() == null || c.getOrderIndex() != i) {
+                c.setOrderIndex(i);
+                repository.save(c);
+            }
+        }
+        return card;
+    }
+
     public Card updateContent(String id, UpdateCardContentRequest request) {
         Card card = repository.findById(id)
                 .orElseThrow(() -> new CardNotFoundException(id));

--- a/backend/src/main/java/com/example/taskmanagement/card/UpdateCardPositionRequest.java
+++ b/backend/src/main/java/com/example/taskmanagement/card/UpdateCardPositionRequest.java
@@ -1,0 +1,11 @@
+package com.example.taskmanagement.card;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record UpdateCardPositionRequest(
+        @NotBlank @Pattern(regexp = "todo|doing|done") String columnId,
+        @NotNull @PositiveOrZero Integer orderIndex
+) {}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,9 @@
       "name": "task-management-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "axios": "^1.15.2",
         "react": "^19.2.5",
         "react-dom": "^19.2.5"
@@ -286,6 +289,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -3435,9 +3491,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,9 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "axios": "^1.15.2",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"

--- a/frontend/src/api/cards.ts
+++ b/frontend/src/api/cards.ts
@@ -36,3 +36,16 @@ export async function updateCardContent(
   const res = await apiClient.put<Card>(`/cards/${id}`, input);
   return res.data;
 }
+
+export interface UpdateCardPositionInput {
+  columnId: ColumnId;
+  orderIndex: number;
+}
+
+export async function updateCardPosition(
+  id: string,
+  input: UpdateCardPositionInput,
+): Promise<Card> {
+  const res = await apiClient.patch<Card>(`/cards/${id}/position`, input);
+  return res.data;
+}

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -1,8 +1,30 @@
 import { useEffect, useState } from 'react';
-import { createCard, fetchCards, type CardCreateInput } from '../api/cards';
+import {
+  DndContext,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragOverEvent,
+} from '@dnd-kit/core';
+import {
+  createCard,
+  fetchCards,
+  updateCardPosition,
+  type CardCreateInput,
+} from '../api/cards';
 import { COLUMNS, type Card, type ColumnId } from '../types/card';
 import CardEditModal from './CardEditModal';
 import Column from './Column';
+
+const COLUMN_DROPPABLE_PREFIX = 'column:';
+
+function findColumnOf(data: Record<ColumnId, Card[]>, cardId: string): ColumnId | null {
+  for (const c of COLUMNS) {
+    if (data[c.id].some((x) => x.id === cardId)) return c.id;
+  }
+  return null;
+}
 
 type CardsByColumn = Record<ColumnId, Card[]>;
 
@@ -45,6 +67,135 @@ export default function Board() {
     };
   }, []);
 
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  );
+
+  const refetchAll = async () => {
+    const results = await Promise.all(COLUMNS.map((c) => fetchCards(c.id)));
+    const next: CardsByColumn = { todo: [], doing: [], done: [] };
+    COLUMNS.forEach((c, i) => {
+      next[c.id] = [...results[i]].sort((a, b) => a.orderIndex - b.orderIndex);
+    });
+    setData(next);
+  };
+
+  const resolveTargetColumn = (overId: string, current: CardsByColumn): ColumnId | null => {
+    if (overId.startsWith(COLUMN_DROPPABLE_PREFIX)) {
+      return overId.slice(COLUMN_DROPPABLE_PREFIX.length) as ColumnId;
+    }
+    return findColumnOf(current, overId);
+  };
+
+  const handleDragOver = (event: DragOverEvent) => {
+    const { active, over } = event;
+    if (!over) return;
+    const cardId = String(active.id);
+    const overId = String(over.id);
+    if (cardId === overId) return;
+
+    setData((prev) => {
+      const fromColumn = findColumnOf(prev, cardId);
+      if (!fromColumn) return prev;
+      const toColumn = resolveTargetColumn(overId, prev);
+      if (!toColumn || fromColumn === toColumn) return prev;
+
+      const card = prev[fromColumn].find((c) => c.id === cardId);
+      if (!card) return prev;
+      const fromList = prev[fromColumn].filter((c) => c.id !== cardId);
+      const toList = [...prev[toColumn]];
+      const insertAt = overId.startsWith(COLUMN_DROPPABLE_PREFIX)
+        ? toList.length
+        : Math.max(0, toList.findIndex((c) => c.id === overId));
+      toList.splice(insertAt, 0, { ...card, columnId: toColumn });
+      return { ...prev, [fromColumn]: fromList, [toColumn]: toList };
+    });
+  };
+
+  const handleDragEnd = async (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over) return;
+    const cardId = String(active.id);
+    const overId = String(over.id);
+
+    const toColumn = findColumnOf(data, cardId);
+    if (!toColumn) return;
+    const currentIndex = data[toColumn].findIndex((c) => c.id === cardId);
+    if (currentIndex < 0) return;
+
+    let targetIndex: number;
+    if (cardId === overId || overId.startsWith(COLUMN_DROPPABLE_PREFIX)) {
+      targetIndex = currentIndex;
+    } else {
+      const overCol = findColumnOf(data, overId);
+      const overIdx = overCol === toColumn ? data[toColumn].findIndex((c) => c.id === overId) : -1;
+      targetIndex = overIdx >= 0 ? overIdx : currentIndex;
+    }
+
+    const prevData = data;
+    if (targetIndex !== currentIndex) {
+      setData((p) => {
+        const next = [...p[toColumn]];
+        const [moved] = next.splice(currentIndex, 1);
+        next.splice(targetIndex, 0, moved);
+        return { ...p, [toColumn]: next };
+      });
+    }
+
+    try {
+      await updateCardPosition(cardId, { columnId: toColumn, orderIndex: targetIndex });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'カードの移動に失敗しました');
+      setData(prevData);
+      void refetchAll();
+    }
+  };
+
+  const PRIORITY_ORDER: Record<string, number> = { high: 0, medium: 1, low: 2 };
+  const SORT_MODES = ['priority', 'dueDate'] as const;
+  type SortMode = (typeof SORT_MODES)[number];
+
+  const [sortMode, setSortMode] = useState<Record<ColumnId, SortMode>>({
+    todo: 'priority',
+    doing: 'priority',
+    done: 'priority',
+  });
+
+  const sortCards = (cards: Card[], mode: SortMode): Card[] => {
+    return [...cards].sort((a, b) => {
+      if (mode === 'priority') {
+        return PRIORITY_ORDER[a.priority] - PRIORITY_ORDER[b.priority];
+      }
+      const av = a.dueDate;
+      const bv = b.dueDate;
+      if (!av && !bv) return 0;
+      if (!av) return 1;
+      if (!bv) return -1;
+      return av < bv ? -1 : av > bv ? 1 : 0;
+    });
+  };
+
+  const handleSort = async (columnId: ColumnId) => {
+    const mode = sortMode[columnId];
+    const sorted = sortCards(data[columnId], mode);
+    const prevData = data;
+    setData((p) => ({ ...p, [columnId]: sorted }));
+    setSortMode((prev) => {
+      const idx = SORT_MODES.indexOf(prev[columnId]);
+      const next = SORT_MODES[(idx + 1) % SORT_MODES.length];
+      return { ...prev, [columnId]: next };
+    });
+    try {
+      for (let i = 0; i < sorted.length; i++) {
+        await updateCardPosition(sorted[i].id, { columnId, orderIndex: i });
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'カードの並び替えに失敗しました');
+      setData(prevData);
+      void refetchAll();
+    }
+  };
+
   const handleCreate = async (
     columnId: ColumnId,
     input: Omit<CardCreateInput, 'columnId' | 'orderIndex'>,
@@ -78,18 +229,22 @@ export default function Board() {
           {error}
         </div>
       )}
-      <div className="flex gap-4 overflow-x-auto">
-        {COLUMNS.map((c) => (
-          <Column
-            key={c.id}
-            columnId={c.id}
-            label={c.label}
-            cards={data[c.id]}
-            onCreate={handleCreate}
-            onCardClick={setEditing}
-          />
-        ))}
-      </div>
+      <DndContext sensors={sensors} onDragOver={handleDragOver} onDragEnd={handleDragEnd}>
+        <div className="flex gap-4 overflow-x-auto">
+          {COLUMNS.map((c) => (
+            <Column
+              key={c.id}
+              columnId={c.id}
+              label={c.label}
+              cards={data[c.id]}
+              onCreate={handleCreate}
+              onCardClick={setEditing}
+              onSort={handleSort}
+              nextSortMode={sortMode[c.id]}
+            />
+          ))}
+        </div>
+      </DndContext>
       {editing && (
         <CardEditModal
           card={editing}

--- a/frontend/src/components/CardItem.tsx
+++ b/frontend/src/components/CardItem.tsx
@@ -1,3 +1,5 @@
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import type { Card } from '../types/card';
 import PriorityBadge from './PriorityBadge';
 
@@ -15,9 +17,23 @@ interface Props {
 }
 
 export default function CardItem({ card, onClick }: Props) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: card.id,
+  });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : undefined,
+  };
+
   return (
     <article
-      className="cursor-pointer rounded-md border border-gray-200 bg-white p-3 shadow-sm hover:border-blue-300 hover:shadow"
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      className="cursor-grab rounded-md border border-gray-200 bg-white p-3 shadow-sm hover:border-blue-300 hover:shadow active:cursor-grabbing"
       onClick={() => onClick?.(card)}
     >
       <h3 className="mb-2 text-sm font-medium text-gray-900">{card.title}</h3>

--- a/frontend/src/components/Column.tsx
+++ b/frontend/src/components/Column.tsx
@@ -1,8 +1,12 @@
 import { useState } from 'react';
+import { useDroppable } from '@dnd-kit/core';
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import type { CardCreateInput } from '../api/cards';
 import type { Card, ColumnId } from '../types/card';
 import CardItem from './CardItem';
 import CardCreateForm from './CardCreateForm';
+
+export const columnDroppableId = (columnId: ColumnId) => `column:${columnId}`;
 
 interface Props {
   columnId: ColumnId;
@@ -13,10 +17,26 @@ interface Props {
     input: Omit<CardCreateInput, 'columnId' | 'orderIndex'>,
   ) => Promise<void>;
   onCardClick?: (card: Card) => void;
+  onSort?: (columnId: ColumnId) => Promise<void> | void;
+  nextSortMode?: 'priority' | 'dueDate';
 }
 
-export default function Column({ columnId, label, cards, onCreate, onCardClick }: Props) {
+const SORT_LABEL: Record<'priority' | 'dueDate', string> = {
+  priority: '優先度順',
+  dueDate: '期日順',
+};
+
+export default function Column({
+  columnId,
+  label,
+  cards,
+  onCreate,
+  onCardClick,
+  onSort,
+  nextSortMode,
+}: Props) {
   const [adding, setAdding] = useState(false);
+  const { setNodeRef } = useDroppable({ id: columnDroppableId(columnId) });
 
   const handleSubmit = async (
     input: Omit<CardCreateInput, 'columnId' | 'orderIndex'>,
@@ -26,27 +46,44 @@ export default function Column({ columnId, label, cards, onCreate, onCardClick }
   };
 
   return (
-    <section className="flex w-80 flex-shrink-0 flex-col rounded-lg bg-gray-100 p-3">
+    <section
+      ref={setNodeRef}
+      className="flex w-80 flex-shrink-0 flex-col rounded-lg bg-gray-100 p-3"
+    >
       <header className="mb-3 flex items-center justify-between px-1">
         <h2 className="text-sm font-semibold text-gray-700">
           {label} <span className="ml-1 text-gray-500">({cards.length})</span>
         </h2>
-        {!adding && (
-          <button
-            type="button"
-            onClick={() => setAdding(true)}
-            className="rounded px-2 py-1 text-xs text-gray-600 hover:bg-gray-200"
-          >
-            ＋ 追加
-          </button>
-        )}
+        <div className="flex items-center gap-1">
+          {onSort && cards.length > 1 && (
+            <button
+              type="button"
+              onClick={() => onSort(columnId)}
+              className="rounded px-2 py-1 text-xs text-gray-600 hover:bg-gray-200"
+              title={nextSortMode ? `${SORT_LABEL[nextSortMode]}に並び替え` : '並び替え'}
+            >
+              ⇅ {nextSortMode ? SORT_LABEL[nextSortMode] : '並び替え'}
+            </button>
+          )}
+          {!adding && (
+            <button
+              type="button"
+              onClick={() => setAdding(true)}
+              className="rounded px-2 py-1 text-xs text-gray-600 hover:bg-gray-200"
+            >
+              ＋ 追加
+            </button>
+          )}
+        </div>
       </header>
-      <div className="flex flex-col gap-2">
-        {cards.length === 0 && !adding ? (
-          <p className="py-6 text-center text-sm text-gray-400">カードがありません</p>
-        ) : (
-          cards.map((c) => <CardItem key={c.id} card={c} onClick={onCardClick} />)
-        )}
+      <div className="flex min-h-[40px] flex-col gap-2">
+        <SortableContext items={cards.map((c) => c.id)} strategy={verticalListSortingStrategy}>
+          {cards.length === 0 && !adding ? (
+            <p className="py-6 text-center text-sm text-gray-400">カードがありません</p>
+          ) : (
+            cards.map((c) => <CardItem key={c.id} card={c} onClick={onCardClick} />)
+          )}
+        </SortableContext>
         {adding && (
           <CardCreateForm
             columnId={columnId}


### PR DESCRIPTION
## Summary
- カードのカラム間ドラッグ&ドロップ移動・同一カラム内並び替えを dnd-kit で実装
- 各カラムヘッダーに並び替えボタンを追加し、優先度順 ↔ 期日順 をトグル

## 変更内容
### バックエンド
- `PATCH /api/cards/{id}/position` を追加（移動元・移動先カラムの orderIndex を 0..N-1 に詰め直し）
- `UpdateCardPositionRequest` (新規)、`CardService.updatePosition`、`CardController.updatePosition`

### フロントエンド
- 依存追加: `@dnd-kit/core` / `@dnd-kit/sortable` / `@dnd-kit/utilities`
- `Board` を `DndContext` でラップ。`onDragOver` でカラム間 hover 中も押し退けが起きるように対応し、`onDragEnd` で API を呼ぶ
- `Column` に `useDroppable` + `SortableContext`、ヘッダーに「⇅ 並び替え」ボタンを追加（次に適用するモードを文言で表示）
- `CardItem` に `useSortable` を適用、PointerSensor の activation distance=5 で「クリック=編集モーダル」「ドラッグ=移動」を両立
- 楽観的更新を行い、API 失敗時は再フェッチでロールバック

## Test plan
- [x] curl で同一カラム内並び替え / カラム間移動 / 不正な columnId(400) を確認
- [x] ブラウザで DnD（同一カラム / カラム間 / 空カラム）を確認
- [x] ブラウザで並び替えボタンが優先度順 ↔ 期日順 をトグルすることを確認
- [x] フロント tsc / バックエンド compileJava 通過

Closes #18