### PR TITLE
feat: 編集モーダルからステータス（カラム）を変更可能に

### DIFF
--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -37,12 +37,16 @@ export default function Board() {
   const [editing, setEditing] = useState<Card | null>(null);
 
   const handleCardSaved = (updated: Card) => {
-    setData((prev) => ({
-      ...prev,
-      [updated.columnId]: prev[updated.columnId]
-        .map((c) => (c.id === updated.id ? updated : c))
-        .sort((a, b) => a.orderIndex - b.orderIndex),
-    }));
+    setData((prev) => {
+      const next: CardsByColumn = { todo: [], doing: [], done: [] };
+      for (const c of COLUMNS) {
+        next[c.id] = prev[c.id].filter((card) => card.id !== updated.id);
+      }
+      next[updated.columnId] = [...next[updated.columnId], updated].sort(
+        (a, b) => a.orderIndex - b.orderIndex,
+      );
+      return next;
+    });
   };
 
   useEffect(() => {
@@ -248,6 +252,11 @@ export default function Board() {
       {editing && (
         <CardEditModal
           card={editing}
+          cardCountsByColumn={{
+            todo: data.todo.length,
+            doing: data.doing.length,
+            done: data.done.length,
+          }}
           onClose={() => setEditing(null)}
           onSaved={handleCardSaved}
         />

--- a/frontend/src/components/CardEditModal.tsx
+++ b/frontend/src/components/CardEditModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
-import { updateCardContent } from '../api/cards';
-import type { Card, Priority } from '../types/card';
+import { updateCardContent, updateCardPosition } from '../api/cards';
+import { COLUMNS, type Card, type ColumnId, type Priority } from '../types/card';
 
 const PRIORITY_OPTIONS: { value: Priority; label: string }[] = [
   { value: 'high', label: '高' },
@@ -10,15 +10,17 @@ const PRIORITY_OPTIONS: { value: Priority; label: string }[] = [
 
 interface Props {
   card: Card;
+  cardCountsByColumn: Record<ColumnId, number>;
   onClose: () => void;
   onSaved: (card: Card) => void;
 }
 
-export default function CardEditModal({ card, onClose, onSaved }: Props) {
+export default function CardEditModal({ card, cardCountsByColumn, onClose, onSaved }: Props) {
   const [title, setTitle] = useState(card.title);
   const [description, setDescription] = useState(card.description ?? '');
   const [priority, setPriority] = useState<Priority>(card.priority);
   const [dueDate, setDueDate] = useState<string>(card.dueDate ?? '');
+  const [columnId, setColumnId] = useState<ColumnId>(card.columnId);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -39,12 +41,18 @@ export default function CardEditModal({ card, onClose, onSaved }: Props) {
     setSubmitting(true);
     setError(null);
     try {
-      const updated = await updateCardContent(card.id, {
+      let updated = await updateCardContent(card.id, {
         title: title.trim(),
         description,
         priority,
         dueDate: dueDate ? dueDate : null,
       });
+      if (columnId !== card.columnId) {
+        updated = await updateCardPosition(card.id, {
+          columnId,
+          orderIndex: cardCountsByColumn[columnId],
+        });
+      }
       onSaved(updated);
       onClose();
     } catch (err) {
@@ -85,6 +93,20 @@ export default function CardEditModal({ card, onClose, onSaved }: Props) {
               rows={5}
               className="rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none"
             />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="text-gray-700">ステータス</span>
+            <select
+              value={columnId}
+              onChange={(e) => setColumnId(e.target.value as ColumnId)}
+              className="rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none"
+            >
+              {COLUMNS.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.label}
+                </option>
+              ))}
+            </select>
           </label>
           <div className="flex gap-3">
             <label className="flex flex-1 flex-col gap-1 text-sm">


### PR DESCRIPTION
## Summary
- 編集モーダルにステータス（カラム）の select を追加
- 保存時に columnId が変わっていれば updateCardPosition を呼び、移動先カラムの末尾にカードを移動
- DnD が使えない環境向けの代替手段（要件定義書の指示）

## 変更内容
- `CardEditModal`: `columnId` state とステータス select、保存時の position API 呼び出し
- `Board.handleCardSaved`: 全カラムから対象 ID を除去 → 更新後の columnId 配列に追加 → orderIndex でソート

## Test plan
- [x] ステータスを変更して保存 → カードが新カラム末尾へ移動
- [x] ステータスを変えず内容だけ更新 → 位置 API は呼ばれない / 元の位置で表示更新
- [x] DnD・並び替えボタンが引き続き動作
- [x] フロント tsc 通過

Closes #20