### PR TITLE
feat: カード削除機能を追加 (物理削除)

### DIFF
--- a/backend/src/main/java/com/example/taskmanagement/card/CardController.java
+++ b/backend/src/main/java/com/example/taskmanagement/card/CardController.java
@@ -3,6 +3,7 @@ package com.example.taskmanagement.card;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -52,5 +53,11 @@ public class CardController {
     @PatchMapping("/{id}/position")
     public Card updatePosition(@PathVariable String id, @Valid @RequestBody UpdateCardPositionRequest request) {
         return service.updatePosition(id, request);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable String id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/example/taskmanagement/card/CardService.java
+++ b/backend/src/main/java/com/example/taskmanagement/card/CardService.java
@@ -90,6 +90,22 @@ public class CardService {
         return repository.save(card);
     }
 
+    public void delete(String id) {
+        Card card = repository.findById(id)
+                .orElseThrow(() -> new CardNotFoundException(id));
+        String columnId = card.getColumnId();
+        repository.delete(card);
+
+        List<Card> siblings = repository.findByColumnIdOrderByOrderIndexAsc(columnId);
+        for (int i = 0; i < siblings.size(); i++) {
+            Card c = siblings.get(i);
+            if (c.getOrderIndex() == null || c.getOrderIndex() != i) {
+                c.setOrderIndex(i);
+                repository.save(c);
+            }
+        }
+    }
+
     public Card create(CardCreateRequest request) {
         Card card = new Card();
         card.setTitle(request.title());

--- a/frontend/src/api/cards.ts
+++ b/frontend/src/api/cards.ts
@@ -49,3 +49,7 @@ export async function updateCardPosition(
   const res = await apiClient.patch<Card>(`/cards/${id}/position`, input);
   return res.data;
 }
+
+export async function deleteCard(id: string): Promise<void> {
+  await apiClient.delete(`/cards/${id}`);
+}

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -36,6 +36,17 @@ export default function Board() {
   const [error, setError] = useState<string | null>(null);
   const [editing, setEditing] = useState<Card | null>(null);
 
+  const handleCardDeleted = (cardId: string) => {
+    setData((prev) => {
+      const next: CardsByColumn = { todo: [], doing: [], done: [] };
+      for (const c of COLUMNS) {
+        next[c.id] = prev[c.id].filter((card) => card.id !== cardId);
+      }
+      return next;
+    });
+    void refetchAll();
+  };
+
   const handleCardSaved = (updated: Card) => {
     setData((prev) => {
       const next: CardsByColumn = { todo: [], doing: [], done: [] };
@@ -259,6 +270,7 @@ export default function Board() {
           }}
           onClose={() => setEditing(null)}
           onSaved={handleCardSaved}
+          onDeleted={handleCardDeleted}
         />
       )}
     </div>

--- a/frontend/src/components/CardEditModal.tsx
+++ b/frontend/src/components/CardEditModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { updateCardContent, updateCardPosition } from '../api/cards';
+import { deleteCard, updateCardContent, updateCardPosition } from '../api/cards';
 import { COLUMNS, type Card, type ColumnId, type Priority } from '../types/card';
 
 const PRIORITY_OPTIONS: { value: Priority; label: string }[] = [
@@ -13,9 +13,10 @@ interface Props {
   cardCountsByColumn: Record<ColumnId, number>;
   onClose: () => void;
   onSaved: (card: Card) => void;
+  onDeleted: (cardId: string) => void;
 }
 
-export default function CardEditModal({ card, cardCountsByColumn, onClose, onSaved }: Props) {
+export default function CardEditModal({ card, cardCountsByColumn, onClose, onSaved, onDeleted }: Props) {
   const [title, setTitle] = useState(card.title);
   const [description, setDescription] = useState(card.description ?? '');
   const [priority, setPriority] = useState<Priority>(card.priority);
@@ -58,6 +59,20 @@ export default function CardEditModal({ card, cardCountsByColumn, onClose, onSav
     } catch (err) {
       setError(err instanceof Error ? err.message : '更新に失敗しました');
     } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!window.confirm('このカードを削除しますか？')) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await deleteCard(card.id);
+      onDeleted(card.id);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '削除に失敗しました');
       setSubmitting(false);
     }
   };
@@ -138,7 +153,16 @@ export default function CardEditModal({ card, cardCountsByColumn, onClose, onSav
               {error}
             </p>
           )}
-          <div className="flex justify-end gap-2">
+          <div className="flex items-center justify-between gap-2">
+            <button
+              type="button"
+              onClick={handleDelete}
+              className="rounded border border-red-300 px-3 py-1 text-sm text-red-700 hover:bg-red-50 disabled:opacity-50"
+              disabled={submitting}
+            >
+              削除
+            </button>
+            <div className="flex gap-2">
             <button
               type="button"
               onClick={onClose}
@@ -154,6 +178,7 @@ export default function CardEditModal({ card, cardCountsByColumn, onClose, onSav
             >
               {submitting ? '保存中…' : '保存'}
             </button>
+            </div>
           </div>
         </form>
       </div>


### PR DESCRIPTION
## Summary
- 編集モーダルからカードを削除できるようにした (物理削除)
- `DELETE /api/cards/{id}` を追加し、削除後は同カラム内の orderIndex を再採番
- 学習用アプリで復元・監査要件がないため論理削除は採用しない

Closes #22

## Test plan
- [x] curl で DELETE → 204、再GET → 404、存在しないID DELETE → 404 を確認
- [x] ブラウザでカード作成 → 編集モーダルから削除 → ボードから消えること
- [x] リロード後も復活しないこと (物理削除確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)