### PR TITLE
chore: Terraform 雛形と tfstate 基盤 (#26)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,13 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+# Terraform
+**/.terraform/
+*.tfstate
+*.tfstate.*
+*.tfvars
+!*.tfvars.example
+
+# SSH private keys
+*.pem

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,129 @@
+# infra/ — TaskManagement AWS デプロイ (Terraform)
+
+スクール課題向け・個人利用前提で、**AWS 無料枠($0 運用)** で TaskManagement をデプロイするための Terraform 設定。
+
+## フェーズ全体像
+
+```
+Phase 1: EC2 1台に Front+Back+DB 同居 (現在ここ)
+   ↓
+Phase 2: DB を RDS に切り出す
+   ↓
+Phase 3: フロントを S3 + CloudFront に切り出す
+```
+
+詳細は GitHub Issue #26 (全体計画) を参照。
+
+## このディレクトリの中身
+
+| ファイル | 役割 |
+|---|---|
+| `backend.tf` | tfstate を S3 + DynamoDB ロックで管理 (無料枠内) |
+| `providers.tf` | AWS プロバイダ (`ap-northeast-1`) と共通タグ |
+| `variables.tf` | 入力変数 (project / region / my_ip / key_name) |
+| `terraform.tfvars.example` | `terraform.tfvars` の雛形。自分の IP を埋める |
+
+> 後続ステップで `network.tf` `security.tf` `ec2.tf` `user_data.sh` などを追加していく。
+
+## なぜ S3 + DynamoDB を使うのか (tfstate 用)
+
+Terraform は「現在 AWS に何を作ったか」を `terraform.tfstate` というファイルで管理する。これを **S3 に保管 + DynamoDB でロック** することで以下を実現する:
+
+- 状態ファイルの紛失防止 (S3 のバージョニング有効)
+- 複数人 / 複数 PC からの同時更新による破損防止 (DynamoDB ロック)
+- 実務で標準的に使われるパターンの学習
+
+> S3 5GB / DynamoDB 25GB は **Always Free** 枠で課金されない。
+
+## 前提
+
+ローカルに以下が揃っていること:
+- AWS CLI (`aws --version`)
+- Terraform 1.6 以上 (`terraform -version`)
+- `aws configure` で `ap-northeast-1` の IAM ユーザー認証情報を設定済み (`aws sts get-caller-identity` で確認)
+
+## 初回セットアップ手順
+
+### 1. tfstate 用の S3 バケットと DynamoDB テーブル
+
+Step #1 で AWS CLI から既に作成済み。再構築が必要な場合のみ以下を実行:
+
+```bash
+aws s3api create-bucket \
+  --bucket taskmanagement-tfstate-okkun \
+  --region ap-northeast-1 \
+  --create-bucket-configuration LocationConstraint=ap-northeast-1
+aws s3api put-bucket-versioning --bucket taskmanagement-tfstate-okkun \
+  --versioning-configuration Status=Enabled
+aws s3api put-public-access-block --bucket taskmanagement-tfstate-okkun \
+  --public-access-block-configuration \
+  BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true
+aws s3api put-bucket-encryption --bucket taskmanagement-tfstate-okkun \
+  --server-side-encryption-configuration \
+  '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}'
+
+aws dynamodb create-table --table-name taskmanagement-tflock \
+  --attribute-definitions AttributeName=LockID,AttributeType=S \
+  --key-schema AttributeName=LockID,KeyType=HASH \
+  --billing-mode PAY_PER_REQUEST --region ap-northeast-1
+```
+
+### 2. EC2 用 SSH キーペアを作成 (ローカル + AWS)
+
+**秘密鍵をログに残さないため、自分の手で 1 度だけ実行する。**
+
+```bash
+aws ec2 create-key-pair \
+  --key-name taskmanagement-key \
+  --region ap-northeast-1 \
+  --query 'KeyMaterial' --output text > ~/.ssh/taskmanagement-key.pem
+chmod 400 ~/.ssh/taskmanagement-key.pem
+```
+
+確認:
+```bash
+ls -l ~/.ssh/taskmanagement-key.pem
+aws ec2 describe-key-pairs --key-names taskmanagement-key --region ap-northeast-1
+```
+
+### 3. terraform.tfvars を作る
+
+```bash
+cd infra
+cp terraform.tfvars.example terraform.tfvars
+# 自分のグローバル IP を確認
+curl -s https://checkip.amazonaws.com
+# terraform.tfvars の my_ip を "<上記IP>/32" に書き換える
+```
+
+### 4. terraform init
+
+```bash
+cd infra
+terraform init
+```
+
+成功すれば `Terraform has been successfully initialized!` が表示される。
+
+## 後片付け (課題提出後・課金停止)
+
+```bash
+# 1. Terraform で作ったリソースを全削除
+cd infra
+terraform destroy
+
+# 2. tfstate 用のリソースも消す (任意・ただし無料枠内)
+aws s3 rm s3://taskmanagement-tfstate-okkun --recursive
+aws s3api delete-bucket --bucket taskmanagement-tfstate-okkun --region ap-northeast-1
+aws dynamodb delete-table --table-name taskmanagement-tflock --region ap-northeast-1
+
+# 3. SSH キーペア
+aws ec2 delete-key-pair --key-name taskmanagement-key --region ap-northeast-1
+rm ~/.ssh/taskmanagement-key.pem
+```
+
+## 注意事項
+
+- `terraform.tfvars` / `.terraform/` / `*.tfstate*` / `*.pem` は **絶対に Git にコミットしない** (`.gitignore` で除外済み)
+- 12ヶ月の無料枠を超えると EC2 / EBS が課金対象。**使わなくなったら必ず `terraform destroy`**
+- DB パスワードや自宅 IP などの秘密値は `terraform.tfvars` に置く

--- a/infra/backend.tf
+++ b/infra/backend.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  backend "s3" {
+    bucket         = "taskmanagement-tfstate-okkun"
+    key            = "phase1/terraform.tfstate"
+    region         = "ap-northeast-1"
+    dynamodb_table = "taskmanagement-tflock"
+    encrypt        = true
+  }
+}

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Project     = var.project
+      Environment = "phase1"
+      ManagedBy   = "terraform"
+    }
+  }
+}

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -1,0 +1,8 @@
+# このファイルを `terraform.tfvars` にコピーして自分の値を埋めてください。
+# `terraform.tfvars` は .gitignore で除外されています。
+#
+#   cp terraform.tfvars.example terraform.tfvars
+#   # 自分のグローバル IP を確認:  curl -s https://checkip.amazonaws.com
+#   # 例: 203.0.113.10 → "203.0.113.10/32"
+
+my_ip = "0.0.0.0/32"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,22 @@
+variable "project" {
+  description = "プロジェクト識別子。リソース名・タグの prefix に使う"
+  type        = string
+  default     = "taskmanagement"
+}
+
+variable "region" {
+  description = "デプロイ先 AWS リージョン"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "my_ip" {
+  description = "SSH 接続を許可する自宅 IP (CIDR 形式 例: 203.0.113.10/32)。terraform.tfvars で設定し Git にコミットしないこと"
+  type        = string
+}
+
+variable "key_name" {
+  description = "EC2 にアタッチする SSH キーペア名 (事前に AWS CLI で作成済みのもの)"
+  type        = string
+  default     = "taskmanagement-key"
+}


### PR DESCRIPTION
## Summary

- Phase 1 (EC2 1台同居構成) のデプロイに向けた Terraform プロジェクトの土台を整備
- `infra/` 配下に S3 backend / AWS provider / 変数定義の雛形ファイルを追加
- tfstate 用 S3 バケットと DynamoDB ロックテーブルを AWS CLI で作成済み (無料枠内)
- `.gitignore` に Terraform / SSH 秘密鍵の除外を追加
- `terraform init` が成功することを確認

まだ AWS 上に VPC/EC2 等は作成していない。後続 Issue で順次追加する。

## 構成

| ファイル | 役割 |
|---|---|
| `infra/backend.tf` | tfstate を S3 + DynamoDB ロックで管理 |
| `infra/providers.tf` | AWS provider (ap-northeast-1) と共通タグ |
| `infra/variables.tf` | project / region / my_ip / key_name |
| `infra/terraform.tfvars.example` | tfvars 雛形 (実体は Git 除外) |
| `infra/README.md` | セットアップ・後片付け手順 |
| `infra/.terraform.lock.hcl` | プロバイダのバージョン固定 (公式推奨でコミット) |

## Test plan

- [x] `terraform init` が成功
- [x] `terraform fmt` で整形済み
- [x] `terraform validate` が成功
- [ ] レビュー後、後続 Issue (Step #2: VPC/SG) を起票

## 補足

- SSH キーペア (`taskmanagement-key`) はチャットログに秘密鍵が出ないようユーザー手元で再生成する手順を `infra/README.md` に記載
- `dynamodb_table` パラメータの非推奨警告が出るが機能には影響なし。将来 `use_lockfile = true` への移行を検討

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)
