### PR TITLE
feat: VPC とセキュリティグループ (#28)

### DIFF
--- a/infra/network.tf
+++ b/infra/network.tf
@@ -1,0 +1,51 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name = "${var.project}-vpc"
+  }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${var.project}-igw"
+  }
+}
+
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.0.1.0/24"
+  availability_zone       = data.aws_availability_zones.available.names[0]
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "${var.project}-public-1"
+    Tier = "public"
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name = "${var.project}-public-rt"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,19 @@
+output "vpc_id" {
+  description = "VPC ID"
+  value       = aws_vpc.main.id
+}
+
+output "public_subnet_id" {
+  description = "Public subnet ID (EC2 配置先)"
+  value       = aws_subnet.public.id
+}
+
+output "ec2_security_group_id" {
+  description = "EC2 用セキュリティグループ ID"
+  value       = aws_security_group.ec2.id
+}
+
+output "availability_zone" {
+  description = "使用中の AZ"
+  value       = aws_subnet.public.availability_zone
+}

--- a/infra/security.tf
+++ b/infra/security.tf
@@ -1,0 +1,33 @@
+resource "aws_security_group" "ec2" {
+  name        = "${var.project}-ec2"
+  description = "TaskManagement EC2: SSH and HTTP from my_ip only"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description = "SSH from my_ip"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [var.my_ip]
+  }
+
+  ingress {
+    description = "HTTP from my_ip"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = [var.my_ip]
+  }
+
+  egress {
+    description = "All outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.project}-ec2-sg"
+  }
+}


### PR DESCRIPTION
## Summary

Phase 1 Step #2: EC2 を起動するためのネットワーク基盤を Terraform で追加。

- VPC `10.0.0.0/16` (DNS hostnames 有効)
- Internet Gateway
- Public Subnet `10.0.1.0/24` (ap-northeast-1a, 自動 Public IP)
- Public Route Table (0.0.0.0/0 → IGW) + Subnet 関連付け
- EC2 用 Security Group: 22 (SSH) / 80 (HTTP) ともに `my_ip` のみ許可、egress 全開放
- `outputs.tf` で `vpc_id` / `public_subnet_id` / `ec2_security_group_id` / `availability_zone` を出力

EC2 自体はまだ作らない (Step #4 で追加)。

## Free tier

すべて課金なし (VPC / IGW / Subnet / Route Table / Security Group は無料)。

## Test plan

- [x] `terraform fmt` / `terraform validate` 通過
- [x] `terraform plan` で `Plan: 6 to add` を確認
- [ ] マージ後に main で `terraform apply` を実行
- [ ] `aws ec2 describe-vpcs / describe-subnets / describe-security-groups` で確認
- [ ] `terraform output` で 4 つの出力値が表示されることを確認

## セキュリティ

- 22 / 80 ともに `var.my_ip` のみ許可 (現時点で自分のグローバル IP のみアクセス可)
- 課題提出などで他人にアクセスさせる必要が出たら、`security.tf` の 80 番ルールの `cidr_blocks` を `["0.0.0.0/0"]` に変更して `terraform apply` で切り替え可能

## 補足

- AZ は `data.aws_availability_zones` 経由で `[0]` を取得 (リージョン名のハードコード回避)
- Phase 2 で RDS を追加する際に 2AZ 化 + private subnet を追加する想定

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)
