### PR TITLE
feat: backend Dockerfile と compose.prod.yaml (#30)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ replay_pid*
 *.tfstate.*
 *.tfvars
 !*.tfvars.example
+tfplan
+*.tfplan
 
 # SSH private keys
 *.pem

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,7 @@
+.gradle
+build
+bin
+.idea
+.vscode
+*.iml
+*.log

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1.7
+
+# --- Build stage ---
+FROM eclipse-temurin:25-jdk AS build
+WORKDIR /workspace
+
+COPY gradlew settings.gradle.kts build.gradle.kts ./
+COPY gradle ./gradle
+RUN chmod +x gradlew && ./gradlew --version
+
+COPY src ./src
+RUN ./gradlew bootJar --no-daemon
+
+# --- Runtime stage ---
+FROM eclipse-temurin:25-jre
+WORKDIR /app
+
+RUN groupadd --system app && useradd --system --gid app app
+
+COPY --from=build /workspace/build/libs/*.jar app.jar
+RUN chown app:app app.jar
+USER app
+
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -1,0 +1,35 @@
+services:
+  db:
+    image: postgres:16-alpine
+    container_name: taskmanagement-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: taskmanagement
+      POSTGRES_USER: task_user
+      POSTGRES_PASSWORD: task_pass
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U task_user -d taskmanagement"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  backend:
+    build:
+      context: ./backend
+    container_name: taskmanagement-backend
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      SERVER_PORT: 8080
+      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/taskmanagement
+      SPRING_DATASOURCE_USERNAME: task_user
+      SPRING_DATASOURCE_PASSWORD: task_pass
+    ports:
+      - "8080:8080"
+
+volumes:
+  pgdata:


### PR DESCRIPTION
## Summary

Phase 1 Step #3: バックエンドを Docker コンテナで動かせるように整備。EC2 (Step #4) に持っていく前にローカルで動作検証する。AWS には触らない。

- `backend/Dockerfile` (multi-stage: `eclipse-temurin:25-jdk` でビルド → `:25-jre` で実行)
  - 非 root ユーザー (`app`) で実行
  - `bootJar` を実行イメージにコピーしてエントリポイント化
- `backend/.dockerignore` (build / .gradle / IDE 関連を除外)
- `compose.prod.yaml` (db + backend、`depends_on.condition: service_healthy` で起動順制御)
  - 既存 `compose.yaml` (DB のみ・ローカル開発用) はそのまま残す
  - DB 接続情報は環境変数 `SPRING_DATASOURCE_*` で注入
- `.gitignore` に `tfplan` を追加 (Terraform の plan バイナリは IP 等の秘密値を含むため Git 管理しない)

## Test plan

- [x] `docker compose -f compose.prod.yaml up --build` でエラーなく起動 (db healthy → backend Up)
- [x] `curl http://localhost:8080/api/cards` が 200 を返す (シードデータ取得)
- [x] `docker compose -f compose.prod.yaml down` で正常停止

## 補足

- DB パスワード `task_pass` は compose に直書き (個人利用・無料枠課題の範囲。Phase 2 で Secrets Manager 化を検討)
- マルチステージにより最終イメージサイズを抑制 (JRE のみ含む)
- Step #4 で同じ `compose.prod.yaml` を EC2 上で利用する想定

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)
