### PR TITLE
feat: EC2 でバックエンド + DB を起動 (#32)

### DIFF
--- a/infra/ec2.tf
+++ b/infra/ec2.tf
@@ -1,0 +1,47 @@
+data "aws_ami" "al2023" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "aws_instance" "app" {
+  ami                         = data.aws_ami.al2023.id
+  instance_type               = "t2.micro"
+  key_name                    = var.key_name
+  subnet_id                   = aws_subnet.public.id
+  vpc_security_group_ids      = [aws_security_group.ec2.id]
+  associate_public_ip_address = true
+
+  user_data                   = file("${path.module}/user_data.sh")
+  user_data_replace_on_change = true
+
+  metadata_options {
+    http_tokens   = "required" # IMDSv2 必須
+    http_endpoint = "enabled"
+  }
+
+  root_block_device {
+    volume_type           = "gp3"
+    volume_size           = 8
+    delete_on_termination = true
+    encrypted             = true
+  }
+
+  tags = {
+    Name = "${var.project}-ec2"
+  }
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -17,3 +17,23 @@ output "availability_zone" {
   description = "使用中の AZ"
   value       = aws_subnet.public.availability_zone
 }
+
+output "ec2_public_dns" {
+  description = "EC2 のパブリック DNS"
+  value       = aws_instance.app.public_dns
+}
+
+output "ec2_public_ip" {
+  description = "EC2 のパブリック IP"
+  value       = aws_instance.app.public_ip
+}
+
+output "ssh_command" {
+  description = "EC2 へ SSH するためのコマンド"
+  value       = "ssh -i ~/.ssh/${var.key_name}.pem ec2-user@${aws_instance.app.public_dns}"
+}
+
+output "api_url" {
+  description = "Spring Boot API の URL"
+  value       = "http://${aws_instance.app.public_dns}:8080/api/cards"
+}

--- a/infra/security.tf
+++ b/infra/security.tf
@@ -19,6 +19,15 @@ resource "aws_security_group" "ec2" {
     cidr_blocks = [var.my_ip]
   }
 
+  # 一時: Step #4 で API 動作確認用に開放。Step #5 で Nginx を入れたら削除する
+  ingress {
+    description = "Spring Boot API from my_ip (temporary, until Step #5)"
+    from_port   = 8080
+    to_port     = 8080
+    protocol    = "tcp"
+    cidr_blocks = [var.my_ip]
+  }
+
   egress {
     description = "All outbound"
     from_port   = 0

--- a/infra/user_data.sh
+++ b/infra/user_data.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euxo pipefail
+# Amazon Linux 2023 初期セットアップ:
+#  - Docker / Docker Compose plugin / git インストール
+#  - TaskManagement を clone
+#  - compose.prod.yaml で backend + db 起動
+
+# 1. パッケージ更新と必要ツール
+dnf -y update
+dnf -y install docker git
+
+# 2. Docker 起動 + ec2-user で sudo なしに使えるように
+systemctl enable --now docker
+usermod -aG docker ec2-user
+
+# 3. Docker Compose plugin (公式 plugin を /usr/libexec/docker/cli-plugins/ に配置)
+DOCKER_CONFIG_DIR=/usr/libexec/docker/cli-plugins
+mkdir -p "$DOCKER_CONFIG_DIR"
+COMPOSE_VERSION="v2.29.7"
+ARCH="$(uname -m)"
+curl -sSL "https://github.com/docker/compose/releases/download/$${COMPOSE_VERSION}/docker-compose-linux-$${ARCH}" \
+  -o "$DOCKER_CONFIG_DIR/docker-compose"
+chmod +x "$DOCKER_CONFIG_DIR/docker-compose"
+
+# 4. リポジトリ取得
+APP_DIR=/opt/taskmanagement
+git clone https://github.com/Hiroyuki-12/TaskManagement.git "$APP_DIR"
+chown -R ec2-user:ec2-user "$APP_DIR"
+
+# 5. compose 起動 (build に時間がかかるため非同期 / ログは journald に流れる)
+cd "$APP_DIR"
+docker compose -f compose.prod.yaml up -d --build


### PR DESCRIPTION
## Summary

Phase 1 Step #4: 初めて AWS 上にアプリを起動するステップ。EC2 t2.micro を立ち上げ、user_data で Docker / git をセットアップ、リポジトリを clone して compose.prod.yaml で backend + postgres を起動する。

## 変更内容

- `infra/ec2.tf` 追加
  - Amazon Linux 2023 (data.aws_ami で最新取得)、t2.micro、x86_64
  - 既存の Public Subnet / SG / key pair (`taskmanagement-key`) を利用
  - EBS: gp3 8GB、暗号化有効、終了時削除
  - IMDSv2 必須 (http_tokens=required)
  - user_data に変更があれば再作成 (user_data_replace_on_change=true)
- `infra/user_data.sh` 追加
  - dnf で docker / git をインストール
  - docker compose plugin (v2.29.7) を `/usr/libexec/docker/cli-plugins` に配置
  - `/opt/taskmanagement` にリポジトリを clone
  - `docker compose -f compose.prod.yaml up -d --build`
- `infra/security.tf` 更新
  - SG に 8080 ingress (my_ip のみ) を**一時**追加。Step #5 で Nginx を入れたら削除予定
- `infra/outputs.tf` 更新
  - `ec2_public_dns` / `ec2_public_ip` / `ssh_command` / `api_url`

## Free tier

すべて無料枠内:
- EC2 t2.micro: 750h/月 (12ヶ月)
- EBS gp3 8GB: 30GB/月 (12ヶ月) のうち 8GB 利用
- データ転送 out: 100GB/月 (Always Free)
- Elastic IP は使わない (公開 DNS は AWS 自動付与の `*.amazonaws.com` を利用)

## Test plan

- [x] `terraform fmt` / `validate` 通過
- [x] `terraform plan` で `1 to add, 1 to change` を確認 (EC2 追加 + SG に 8080 ルール追加)
- [ ] マージ後 main で `terraform apply`
- [ ] `ssh -i ~/.ssh/taskmanagement-key.pem ec2-user@<dns>` で接続成功
- [ ] EC2 上で `docker compose -f /opt/taskmanagement/compose.prod.yaml ps` が `db (healthy)` / `backend (Up)`
- [ ] ローカルから `curl http://<dns>:8080/api/cards` が 200 (シードデータが返る)

## 補足

- user_data はインスタンス起動時に 1 度だけ実行される (失敗時は `/var/log/cloud-init-output.log` で確認)
- バックエンドのビルド (Gradle) は EC2 上で 1 分強かかる想定 (t2.micro でも完走可能)
- リポジトリは Public のため認証不要で clone 可能
- IAM Role は付けていない (SSH 経由で運用、必要になれば後で追加)

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)
