### PR TITLE
fix: user_data の bash 変数エスケープを修正 (#32)

### DIFF
--- a/infra/user_data.sh
+++ b/infra/user_data.sh
@@ -18,7 +18,7 @@ DOCKER_CONFIG_DIR=/usr/libexec/docker/cli-plugins
 mkdir -p "$DOCKER_CONFIG_DIR"
 COMPOSE_VERSION="v2.29.7"
 ARCH="$(uname -m)"
-curl -sSL "https://github.com/docker/compose/releases/download/$${COMPOSE_VERSION}/docker-compose-linux-$${ARCH}" \
+curl -sSL "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-linux-${ARCH}" \
   -o "$DOCKER_CONFIG_DIR/docker-compose"
 chmod +x "$DOCKER_CONFIG_DIR/docker-compose"
 


### PR DESCRIPTION
## Summary

Step #4 のデプロイ動作確認時に発見した hotfix。

`user_data.sh` で `$${COMPOSE_VERSION}` / `$${ARCH}` のように Terraform 補間用エスケープを書いていたが、`file()` 関数は補間処理をしないため、bash がそのまま受け取って `$$` (PID) + リテラル `{VAR}` として展開し、docker compose plugin の URL が壊れていた。

結果として plugin が破損したバイナリで配置され、`docker compose up` が `exec format error` でユーザーデータスクリプトが失敗していた。

修正: `${COMPOSE_VERSION}` / `${ARCH}` (シェル変数) に変更。

## Test plan

- マージ後 main で `terraform apply` → `user_data_replace_on_change` により EC2 が再作成される
- SSH 接続後、`docker compose ps` が backend / db ともに Up
- `curl http://<dns>:8080/api/cards` が 200

Refs #32