### PR TITLE
refactor: プレビルド JAR + GitHub Releases 方式に切替 (#35)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ tfplan
 
 # SSH private keys
 *.pem
+
+# Claude Code local state
+.claude/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,52 @@
+.PHONY: build release deploy redeploy destroy ssh logs status clean
+
+RELEASE_TAG := latest
+JAR_SRC := backend/build/libs/task-management-backend-0.0.1-SNAPSHOT.jar
+
+# JAR をビルドし backend/app.jar に配置 (compose.prod.yaml ローカル検証用も兼ねる)
+build:
+	cd backend && ./gradlew bootJar
+	cp $(JAR_SRC) backend/app.jar
+	@ls -lh backend/app.jar
+
+# JAR を GitHub Releases にアップロード (なければ作成)
+release: build
+	@if gh release view $(RELEASE_TAG) >/dev/null 2>&1; then \
+		echo "updating existing release $(RELEASE_TAG)..."; \
+		gh release upload $(RELEASE_TAG) backend/app.jar --clobber; \
+	else \
+		echo "creating release $(RELEASE_TAG)..."; \
+		gh release create $(RELEASE_TAG) backend/app.jar --title "Latest build" --notes "auto-generated"; \
+	fi
+	@echo "release URL: $$(gh release view $(RELEASE_TAG) --json url -q .url)"
+
+# 初回 / EC2 が無い状態からのデプロイ
+deploy:
+	cd infra && terraform apply
+
+# user_data に変更がない時に EC2 だけ作り直し (新しい JAR を取得させたい時)
+redeploy:
+	cd infra && terraform apply -replace=aws_instance.app
+
+# 全リソース削除 (課題提出後)
+destroy:
+	cd infra && terraform destroy
+
+# EC2 へ SSH
+ssh:
+	@cd infra && eval $$(terraform output -raw ssh_command)
+
+# EC2 上のコンテナログ
+logs:
+	@DNS=$$(cd infra && terraform output -raw ec2_public_dns); \
+	ssh -i ~/.ssh/taskmanagement-key.pem ec2-user@$$DNS 'cd /opt/taskmanagement && sudo docker compose -f compose.prod.yaml logs --tail=100 -f'
+
+# EC2 上のコンテナ状態
+status:
+	@DNS=$$(cd infra && terraform output -raw ec2_public_dns); \
+	ssh -i ~/.ssh/taskmanagement-key.pem ec2-user@$$DNS 'cd /opt/taskmanagement && sudo docker compose -f compose.prod.yaml ps'
+
+# ローカル成果物の掃除
+clean:
+	rm -f backend/app.jar
+	cd backend && ./gradlew clean

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,6 +1,12 @@
 .gradle
 build
 bin
+src
+gradle
+gradlew
+gradlew.bat
+build.gradle.kts
+settings.gradle.kts
 .idea
 .vscode
 *.iml

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,24 +1,16 @@
 # syntax=docker/dockerfile:1.7
+#
+# 事前にローカルで `./gradlew bootJar` を実行し、生成された JAR を
+# `backend/app.jar` として配置してから docker build すること。
+# user_data.sh では GitHub Releases から取得して配置する。
 
-# --- Build stage ---
-FROM eclipse-temurin:25-jdk AS build
-WORKDIR /workspace
-
-COPY gradlew settings.gradle.kts build.gradle.kts ./
-COPY gradle ./gradle
-RUN chmod +x gradlew && ./gradlew --version
-
-COPY src ./src
-RUN ./gradlew bootJar --no-daemon
-
-# --- Runtime stage ---
 FROM eclipse-temurin:25-jre
 WORKDIR /app
 
 RUN groupadd --system app && useradd --system --gid app app
 
-COPY --from=build /workspace/build/libs/*.jar app.jar
-RUN chown app:app app.jar
+COPY app.jar /app/app.jar
+RUN chown app:app /app/app.jar
 USER app
 
 EXPOSE 8080

--- a/infra/README.md
+++ b/infra/README.md
@@ -105,6 +105,32 @@ terraform init
 
 成功すれば `Terraform has been successfully initialized!` が表示される。
 
+### 5. 初回デプロイ (バックエンド JAR を GitHub Releases にアップロードしてから EC2 を作る)
+
+t2.micro 上で Gradle ビルドは重すぎるため、JAR は **ローカル Mac でビルド** して **GitHub Releases** に置き、EC2 はそれを取得する構成。
+
+リポジトリルートに用意した `Makefile` で 1 コマンド化されている:
+
+```bash
+# 1. JAR をビルド + GitHub Releases (タグ "latest") に upload
+make release
+
+# 2. EC2 を起動 (user_data が release から JAR を取得して compose up する)
+make deploy
+```
+
+`make release` 内部で実行されること:
+- `cd backend && ./gradlew bootJar`
+- `cp backend/build/libs/*.jar backend/app.jar`
+- `gh release create latest backend/app.jar` (初回) または `gh release upload latest --clobber` (2 回目以降)
+
+### 更新フロー (コード変更後)
+
+```bash
+make release         # 新しい JAR を release "latest" に上書き upload
+make redeploy        # EC2 を作り直して新 JAR を取得 (terraform apply -replace=aws_instance.app)
+```
+
 ## 後片付け (課題提出後・課金停止)
 
 ```bash

--- a/infra/user_data.sh
+++ b/infra/user_data.sh
@@ -3,6 +3,7 @@ set -euxo pipefail
 # Amazon Linux 2023 初期セットアップ:
 #  - Docker / Docker Compose plugin / git インストール
 #  - TaskManagement を clone
+#  - GitHub Releases から事前ビルド済み JAR を取得して backend/app.jar に配置
 #  - compose.prod.yaml で backend + db 起動
 
 # 1. パッケージ更新と必要ツール
@@ -13,7 +14,7 @@ dnf -y install docker git
 systemctl enable --now docker
 usermod -aG docker ec2-user
 
-# 3. Docker Compose plugin (公式 plugin を /usr/libexec/docker/cli-plugins/ に配置)
+# 3. Docker Compose plugin
 DOCKER_CONFIG_DIR=/usr/libexec/docker/cli-plugins
 mkdir -p "$DOCKER_CONFIG_DIR"
 COMPOSE_VERSION="v2.29.7"
@@ -25,8 +26,15 @@ chmod +x "$DOCKER_CONFIG_DIR/docker-compose"
 # 4. リポジトリ取得
 APP_DIR=/opt/taskmanagement
 git clone https://github.com/Hiroyuki-12/TaskManagement.git "$APP_DIR"
+
+# 5. GitHub Releases から事前ビルド済み JAR を取得
+#    タグ "latest" を release alias として運用 (gh release create / upload --clobber で更新)
+JAR_URL="https://github.com/Hiroyuki-12/TaskManagement/releases/latest/download/app.jar"
+curl -sSL --retry 5 --retry-delay 5 -L "$JAR_URL" -o "$APP_DIR/backend/app.jar"
+test -s "$APP_DIR/backend/app.jar" # 0 byte なら release 未作成
+
 chown -R ec2-user:ec2-user "$APP_DIR"
 
-# 5. compose 起動 (build に時間がかかるため非同期 / ログは journald に流れる)
+# 6. compose 起動 (jre + jar の COPY だけなので軽量・数秒で完了)
 cd "$APP_DIR"
 docker compose -f compose.prod.yaml up -d --build


### PR DESCRIPTION
## Summary

t2.micro (1GB RAM) で Spring Boot 4 + Java 25 の Gradle ビルドを回すと OOM/スラッシングで起動失敗するため、ビルド成果物 (JAR) をローカル Mac で作って GitHub Releases (タグ `latest`) に upload し、EC2 はそれを取得して実行するだけにする構成に切り替える。

## 変更点

- `backend/Dockerfile` を runtime-only 化 (`FROM eclipse-temurin:25-jre` + `COPY app.jar`)
- `backend/.dockerignore` を厳格化 (src / gradle 関連を除外)
- `infra/user_data.sh` で Gradle 関連を削除し、GitHub Releases から `curl` で JAR 取得
- `Makefile` 新規追加: `make release` (build + gh release upload --clobber)、`make deploy` (terraform apply)、`make redeploy` (apply -replace)、`make ssh` / `make logs` / `make status` / `make destroy`
- `infra/README.md` に新ワークフロー記載
- `.gitignore` に `.claude/` を追加

## デプロイフロー

```bash
make release      # ローカルで JAR ビルド → GitHub Releases にアップロード
make deploy       # terraform apply (初回)、または make redeploy (新 JAR を取りに行かせる)
```

## Free tier

完全に無料。GitHub Releases は public リポジトリなら容量制限なし、AWS 側にも追加リソースなし。

## Test plan

- [x] ローカルで `./gradlew bootJar` 成功 (56MB)
- [x] GitHub Release `latest` 作成済 (`https://github.com/Hiroyuki-12/TaskManagement/releases/tag/latest`)
- [ ] マージ後 `make redeploy` で EC2 再作成
- [ ] `ssh -i ~/.ssh/taskmanagement-key.pem ec2-user@<dns>` で接続成功
- [ ] `curl http://<dns>:8080/api/cards` が 200

## なぜ multi-stage を捨てるか

multi-stage の利点 (依存解決の分離による速いキャッシュ) は **ビルドが回る環境** が前提。t2.micro では Gradle ビルド自体が無理なので、multi-stage は無意味。Java の重い処理をすべてローカルに寄せるのが筋。

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)
