### PR TITLE
feat: フロントを Nginx で配信し SG 8080 を閉じる (#37)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ tfplan
 
 # Claude Code local state
 .claude/
+
+# Local release artifact
+frontend-dist.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,33 @@
-.PHONY: build release deploy redeploy destroy ssh logs status clean
+.PHONY: build-backend build-frontend build release deploy redeploy destroy ssh logs status clean
 
 RELEASE_TAG := latest
 JAR_SRC := backend/build/libs/task-management-backend-0.0.1-SNAPSHOT.jar
+FRONT_DIST := frontend/dist
+FRONT_TARBALL := frontend-dist.tar.gz
 
-# JAR をビルドし backend/app.jar に配置 (compose.prod.yaml ローカル検証用も兼ねる)
-build:
+# バックエンド JAR をビルド
+build-backend:
 	cd backend && ./gradlew bootJar
 	cp $(JAR_SRC) backend/app.jar
 	@ls -lh backend/app.jar
 
-# JAR を GitHub Releases にアップロード (なければ作成)
+# フロント dist をビルドして tarball 化
+build-frontend:
+	cd frontend && npm install --no-audit --no-fund && npm run build
+	tar -czf $(FRONT_TARBALL) -C frontend dist
+	@ls -lh $(FRONT_TARBALL)
+
+# 両方ビルド
+build: build-backend build-frontend
+
+# 成果物を GitHub Releases にアップロード (release "latest" を更新)
 release: build
 	@if gh release view $(RELEASE_TAG) >/dev/null 2>&1; then \
-		echo "updating existing release $(RELEASE_TAG)..."; \
-		gh release upload $(RELEASE_TAG) backend/app.jar --clobber; \
+		echo "updating release $(RELEASE_TAG)..."; \
+		gh release upload $(RELEASE_TAG) backend/app.jar $(FRONT_TARBALL) --clobber; \
 	else \
 		echo "creating release $(RELEASE_TAG)..."; \
-		gh release create $(RELEASE_TAG) backend/app.jar --title "Latest build" --notes "auto-generated"; \
+		gh release create $(RELEASE_TAG) backend/app.jar $(FRONT_TARBALL) --title "Latest build" --notes "auto-generated"; \
 	fi
 	@echo "release URL: $$(gh release view $(RELEASE_TAG) --json url -q .url)"
 
@@ -24,11 +35,11 @@ release: build
 deploy:
 	cd infra && terraform apply
 
-# user_data に変更がない時に EC2 だけ作り直し (新しい JAR を取得させたい時)
+# user_data に変更がない時に EC2 だけ作り直し (新しい release を取得させたい時)
 redeploy:
 	cd infra && terraform apply -replace=aws_instance.app
 
-# 全リソース削除 (課題提出後)
+# 全リソース削除
 destroy:
 	cd infra && terraform destroy
 
@@ -44,9 +55,8 @@ logs:
 # EC2 上のコンテナ状態
 status:
 	@DNS=$$(cd infra && terraform output -raw ec2_public_dns); \
-	ssh -i ~/.ssh/taskmanagement-key.pem ec2-user@$$DNS 'cd /opt/taskmanagement && sudo docker compose -f compose.prod.yaml ps'
+	ssh -i ~/.ssh/taskmanagement-key.pem ec2-user@$$DNS 'cd /opt/taskmanagement && sudo docker compose -f compose.prod.yaml ps; echo; sudo systemctl is-active nginx'
 
-# ローカル成果物の掃除
 clean:
-	rm -f backend/app.jar
+	rm -f backend/app.jar $(FRONT_TARBALL)
 	cd backend && ./gradlew clean

--- a/infra/nginx.conf
+++ b/infra/nginx.conf
@@ -1,0 +1,22 @@
+server {
+    listen 80 default_server;
+    server_name _;
+
+    root /var/www/html;
+    index index.html;
+
+    # Spring Boot API へのリバースプロキシ
+    location /api/ {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # SPA: 物理ファイル → なければ index.html (クライアントサイドルーティング対応)
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/infra/security.tf
+++ b/infra/security.tf
@@ -19,15 +19,6 @@ resource "aws_security_group" "ec2" {
     cidr_blocks = [var.my_ip]
   }
 
-  # 一時: Step #4 で API 動作確認用に開放。Step #5 で Nginx を入れたら削除する
-  ingress {
-    description = "Spring Boot API from my_ip (temporary, until Step #5)"
-    from_port   = 8080
-    to_port     = 8080
-    protocol    = "tcp"
-    cidr_blocks = [var.my_ip]
-  }
-
   egress {
     description = "All outbound"
     from_port   = 0

--- a/infra/user_data.sh
+++ b/infra/user_data.sh
@@ -1,16 +1,17 @@
 #!/bin/bash
 set -euxo pipefail
 # Amazon Linux 2023 初期セットアップ:
-#  - Docker / Docker Compose plugin / git インストール
+#  - Docker / Docker Compose plugin / git / nginx インストール
 #  - TaskManagement を clone
-#  - GitHub Releases から事前ビルド済み JAR を取得して backend/app.jar に配置
+#  - GitHub Releases から事前ビルド済み JAR / frontend-dist.tar.gz を取得
 #  - compose.prod.yaml で backend + db 起動
+#  - nginx で / 静的配信 + /api/ をバックエンドにリバプロ
 
 # 1. パッケージ更新と必要ツール
 dnf -y update
-dnf -y install docker git
+dnf -y install docker git nginx tar
 
-# 2. Docker 起動 + ec2-user で sudo なしに使えるように
+# 2. Docker 起動
 systemctl enable --now docker
 usermod -aG docker ec2-user
 
@@ -27,14 +28,32 @@ chmod +x "$DOCKER_CONFIG_DIR/docker-compose"
 APP_DIR=/opt/taskmanagement
 git clone https://github.com/Hiroyuki-12/TaskManagement.git "$APP_DIR"
 
-# 5. GitHub Releases から事前ビルド済み JAR を取得
-#    タグ "latest" を release alias として運用 (gh release create / upload --clobber で更新)
-JAR_URL="https://github.com/Hiroyuki-12/TaskManagement/releases/latest/download/app.jar"
-curl -sSL --retry 5 --retry-delay 5 -L "$JAR_URL" -o "$APP_DIR/backend/app.jar"
-test -s "$APP_DIR/backend/app.jar" # 0 byte なら release 未作成
+# 5. GitHub Releases から成果物を取得
+RELEASE_BASE="https://github.com/Hiroyuki-12/TaskManagement/releases/latest/download"
+
+#   5-1. backend JAR
+curl -sSL --retry 5 --retry-delay 5 -L "${RELEASE_BASE}/app.jar" -o "$APP_DIR/backend/app.jar"
+test -s "$APP_DIR/backend/app.jar"
+
+#   5-2. frontend tarball
+curl -sSL --retry 5 --retry-delay 5 -L "${RELEASE_BASE}/frontend-dist.tar.gz" -o /tmp/frontend-dist.tar.gz
+test -s /tmp/frontend-dist.tar.gz
+rm -rf /var/www/html
+mkdir -p /var/www/html
+tar -xzf /tmp/frontend-dist.tar.gz -C /var/www/html --strip-components=1
+chown -R nginx:nginx /var/www/html
 
 chown -R ec2-user:ec2-user "$APP_DIR"
 
-# 6. compose 起動 (jre + jar の COPY だけなので軽量・数秒で完了)
+# 6. nginx 設定 (リポジトリの infra/nginx.conf を使用)
+#    AL2023 のデフォルト server (default.conf) を無効化し、taskmanagement.conf を配置
+rm -f /etc/nginx/conf.d/default.conf
+cp "$APP_DIR/infra/nginx.conf" /etc/nginx/conf.d/taskmanagement.conf
+nginx -t
+
+# 7. バックエンド起動
 cd "$APP_DIR"
 docker compose -f compose.prod.yaml up -d --build
+
+# 8. nginx 起動
+systemctl enable --now nginx


### PR DESCRIPTION
## Summary

Phase 1 Step #5 (Phase 1 ゴール): フロントエンドを EC2 上の Nginx で配信し、`/api/*` を Spring Boot にリバプロする構成へ。
本 PR マージ + redeploy 後、ブラウザで `http://<ec2-public-dns>` を開くと TaskManagement のカンバン UI が表示される。

## 変更点

- `infra/nginx.conf` 新規: `/` を `/var/www/html` から静的配信 (SPA フォールバック付き)、`/api/` を `127.0.0.1:8080` に `proxy_pass`
- `infra/user_data.sh`:
  - `dnf install nginx tar` 追加
  - GitHub Releases から `frontend-dist.tar.gz` を curl で取得 → `/var/www/html` に展開
  - `infra/nginx.conf` を `/etc/nginx/conf.d/taskmanagement.conf` として配置、`default.conf` を削除
  - `systemctl enable --now nginx`
- `infra/security.tf`: SG から 8080 ingress を削除 (Nginx 経由のみアクセス可)
- `Makefile`:
  - `build-backend` / `build-frontend` を分離
  - `release` ターゲットで `app.jar` と `frontend-dist.tar.gz` の両 asset を upload
- `.gitignore` に `frontend-dist.tar.gz` を追加

## デプロイフロー (今後)

```bash
make release    # JAR + dist tarball を release "latest" に upload
make redeploy   # EC2 を作り直して新 release を取得
```

## Free tier

完全に無料。Nginx は AL2023 の dnf パッケージ、追加 AWS リソースなし。

## Test plan

- [x] frontend `npm run build` 成功 (94KB tarball)
- [x] release `latest` の assets に `app.jar` + `frontend-dist.tar.gz` 揃った
- [ ] マージ後 `make redeploy` で EC2 再作成
- [ ] ブラウザで `http://<dns>` → カンバン UI が見える
- [ ] カード CRUD / DnD / 編集 / 削除 が動く
- [ ] `curl --max-time 5 http://<dns>:8080/api/cards` がタイムアウト (8080 直アクセス不可)

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)
