### PR TITLE
feat: DB を RDS db.t3.micro に切り出し (#41)

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -1,35 +1,13 @@
 services:
-  db:
-    image: postgres:16-alpine
-    container_name: taskmanagement-db
-    restart: unless-stopped
-    environment:
-      POSTGRES_DB: taskmanagement
-      POSTGRES_USER: task_user
-      POSTGRES_PASSWORD: task_pass
-    volumes:
-      - pgdata:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U task_user -d taskmanagement"]
-      interval: 5s
-      timeout: 5s
-      retries: 10
-
   backend:
     build:
       context: ./backend
     container_name: taskmanagement-backend
     restart: unless-stopped
-    depends_on:
-      db:
-        condition: service_healthy
     environment:
       SERVER_PORT: 8080
-      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/taskmanagement
-      SPRING_DATASOURCE_USERNAME: task_user
-      SPRING_DATASOURCE_PASSWORD: task_pass
+      SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL}
+      SPRING_DATASOURCE_USERNAME: ${SPRING_DATASOURCE_USERNAME}
+      SPRING_DATASOURCE_PASSWORD: ${SPRING_DATASOURCE_PASSWORD}
     ports:
       - "8080:8080"
-
-volumes:
-  pgdata:

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,19 +1,25 @@
 # infra/ — TaskManagement AWS デプロイ (Terraform)
 
-スクール課題向けの個人利用前提・**AWS 無料枠 ($0 運用)** で TaskManagement をデプロイするための Terraform 設定。
+スクール課題向けの個人利用前提・**AWS 無料枠** で TaskManagement をデプロイするための Terraform 設定。
 
-## 構成 (Phase 1)
+## 構成 (Phase 2: RDS 切り出し済)
 
 ```
-ユーザー ──HTTP/80──▶ ┌──────────────────────────────────┐
-                    │ EC2 t2.micro (Public Subnet)      │
+ユーザー ──HTTP/80──▶ ┌─────────────────────────────────┐
+                    │ EC2 t2.micro (Public Subnet, AZ-a)│
                     │  ├─ Nginx (80)                    │
                     │  │   ├─ /        → React 静的     │
-                    │  │   └─ /api/*  → :8080 にプロキシ│
-                    │  ├─ Spring Boot (8080) Docker     │
-                    │  └─ PostgreSQL (5432) Docker      │
+                    │  │   └─ /api/*  → :8080           │
+                    │  └─ Spring Boot (8080) Docker     │
                     │  EBS gp3 8GB                      │
-                    └──────────────────────────────────┘
+                    └────────────┬─────────────────────┘
+                                 │ private DNS (5432)
+                                 ▼
+                    ┌─────────────────────────────────┐
+                    │ RDS db.t3.micro                 │
+                    │ PostgreSQL 16 / 20GB gp3        │
+                    │ (Private Subnets AZ-a, AZ-c)    │
+                    └─────────────────────────────────┘
 ```
 
 | AWS リソース | 用途 | 課金 |
@@ -22,6 +28,8 @@
 | Security Group | 22 / 80 を `my_ip` のみ許可 | 無料 |
 | EC2 t2.micro | アプリ実行 | 750h/月 (12ヶ月) |
 | EBS gp3 8GB | EC2 ルートディスク | 30GB/月 (12ヶ月) |
+| RDS db.t3.micro | マネージド PostgreSQL | 750h/月 (12ヶ月) |
+| RDS gp3 20GB | DB ストレージ | 20GB (12ヶ月) |
 | S3 (tfstate) | Terraform 状態管理 | 5GB (12ヶ月) |
 | DynamoDB (tflock) | tfstate ロック | 25GB (Always Free) |
 | データ転送 out | EC2 → ネット | 100GB/月 (Always Free) |
@@ -95,6 +103,7 @@ cd infra
 cp terraform.tfvars.example terraform.tfvars
 curl -s https://checkip.amazonaws.com    # 自分の IP を確認
 # my_ip を "<上記IP>/32" に書き換え
+# db_password を強いランダム文字列に書き換え (生成例: openssl rand -base64 24 | tr -d '/+=')
 ```
 
 ### 4. terraform init
@@ -153,9 +162,15 @@ rm ~/.ssh/taskmanagement-key.pem
 - SSH 22 / HTTP 80 は **`my_ip/32` のみ許可**。第三者に見せたい時だけ `cidr_blocks = ["0.0.0.0/0"]` に一時変更
 - 12ヶ月の無料枠を超えると EC2 / EBS が課金対象。**使わなくなったら必ず `make destroy`**
 
-## 将来の拡張 (Phase 2 以降)
+## 将来の拡張 (Phase 3)
 
-- **Phase 2**: DB を RDS db.t3.micro へ切り出し (12ヶ月無料、その後約 \$15/月)
-- **Phase 3**: GitHub Actions による自動デプロイ、Route53 + ACM で独自ドメイン HTTPS、CloudWatch Logs 集約
+- GitHub Actions による自動デプロイ
+- Route53 + ACM で独自ドメイン HTTPS
+- CloudWatch Logs 集約
 
 > フロントは EC2 上の Nginx 配信で固定。S3 + CloudFront 構成は採用しない。
+
+## 12ヶ月後の課金注意
+
+RDS / EC2 / EBS の無料枠は **12 ヶ月限定**。期限が近づいたら必ず `make destroy` で停止すること。
+RDS を残したまま放置すると月 \$15 程度発生する。

--- a/infra/ec2.tf
+++ b/infra/ec2.tf
@@ -26,8 +26,16 @@ resource "aws_instance" "app" {
   vpc_security_group_ids      = [aws_security_group.ec2.id]
   associate_public_ip_address = true
 
-  user_data                   = file("${path.module}/user_data.sh")
+  user_data = templatefile("${path.module}/user_data.sh.tpl", {
+    db_host     = aws_db_instance.main.address
+    db_port     = aws_db_instance.main.port
+    db_name     = var.db_name
+    db_username = var.db_username
+    db_password = var.db_password
+  })
   user_data_replace_on_change = true
+
+  depends_on = [aws_db_instance.main]
 
   metadata_options {
     http_tokens   = "required" # IMDSv2 必須

--- a/infra/network.tf
+++ b/infra/network.tf
@@ -20,6 +20,7 @@ resource "aws_internet_gateway" "main" {
   }
 }
 
+# Public subnet (EC2 を配置)
 resource "aws_subnet" "public" {
   vpc_id                  = aws_vpc.main.id
   cidr_block              = "10.0.1.0/24"
@@ -29,6 +30,29 @@ resource "aws_subnet" "public" {
   tags = {
     Name = "${var.project}-public-1"
     Tier = "public"
+  }
+}
+
+# Private subnets (RDS 用、AZ 2 つ必須)
+resource "aws_subnet" "private_a" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.11.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
+
+  tags = {
+    Name = "${var.project}-private-a"
+    Tier = "private"
+  }
+}
+
+resource "aws_subnet" "private_c" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.12.0/24"
+  availability_zone = data.aws_availability_zones.available.names[1]
+
+  tags = {
+    Name = "${var.project}-private-c"
+    Tier = "private"
   }
 }
 
@@ -48,4 +72,23 @@ resource "aws_route_table" "public" {
 resource "aws_route_table_association" "public" {
   subnet_id      = aws_subnet.public.id
   route_table_id = aws_route_table.public.id
+}
+
+# プライベート RT は IGW へのルートを持たない (NAT を使わない構成)
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${var.project}-private-rt"
+  }
+}
+
+resource "aws_route_table_association" "private_a" {
+  subnet_id      = aws_subnet.private_a.id
+  route_table_id = aws_route_table.private.id
+}
+
+resource "aws_route_table_association" "private_c" {
+  subnet_id      = aws_subnet.private_c.id
+  route_table_id = aws_route_table.private.id
 }

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -34,6 +34,11 @@ output "ssh_command" {
 }
 
 output "api_url" {
-  description = "Spring Boot API の URL"
-  value       = "http://${aws_instance.app.public_dns}:8080/api/cards"
+  description = "アプリ URL (Nginx 経由)"
+  value       = "http://${aws_instance.app.public_dns}/"
+}
+
+output "rds_endpoint" {
+  description = "RDS のエンドポイント (VPC 内のみ到達可)"
+  value       = aws_db_instance.main.endpoint
 }

--- a/infra/rds.tf
+++ b/infra/rds.tf
@@ -1,0 +1,64 @@
+resource "aws_db_subnet_group" "main" {
+  name       = "${var.project}-db-subnet-group"
+  subnet_ids = [aws_subnet.private_a.id, aws_subnet.private_c.id]
+
+  tags = {
+    Name = "${var.project}-db-subnet-group"
+  }
+}
+
+resource "aws_security_group" "db" {
+  name        = "${var.project}-db"
+  description = "RDS PostgreSQL: allow 5432 only from EC2 SG"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description     = "PostgreSQL from EC2"
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ec2.id]
+  }
+
+  egress {
+    description = "All outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.project}-db-sg"
+  }
+}
+
+resource "aws_db_instance" "main" {
+  identifier        = "${var.project}-db"
+  engine            = "postgres"
+  engine_version    = "16.6"
+  instance_class    = "db.t3.micro"
+  allocated_storage = 20
+  storage_type      = "gp3"
+  storage_encrypted = true
+
+  db_name  = var.db_name
+  username = var.db_username
+  password = var.db_password
+  port     = 5432
+
+  db_subnet_group_name   = aws_db_subnet_group.main.name
+  vpc_security_group_ids = [aws_security_group.db.id]
+  publicly_accessible    = false
+  multi_az               = false
+
+  backup_retention_period    = 1
+  skip_final_snapshot        = true
+  deletion_protection        = false
+  auto_minor_version_upgrade = true
+  apply_immediately          = true
+
+  tags = {
+    Name = "${var.project}-db"
+  }
+}

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -6,3 +6,7 @@
 #   # 例: 203.0.113.10 → "203.0.113.10/32"
 
 my_ip = "0.0.0.0/32"
+
+# RDS の master パスワード (8 文字以上、英数記号で十分強いものに)
+# このファイルではダミー値。terraform.tfvars に強いパスワードを設定すること。
+db_password = "CHANGE_ME_to_strong_password"

--- a/infra/user_data.sh.tpl
+++ b/infra/user_data.sh.tpl
@@ -1,17 +1,17 @@
 #!/bin/bash
 set -euxo pipefail
 # Amazon Linux 2023 初期セットアップ:
-#  - Docker / Docker Compose plugin / git / nginx インストール
-#  - TaskManagement を clone
+#  - Docker / Docker Compose plugin / git / nginx / postgresql client インストール
 #  - GitHub Releases から事前ビルド済み JAR / frontend-dist.tar.gz を取得
-#  - compose.prod.yaml で backend + db 起動
+#  - RDS 接続情報を /opt/taskmanagement/.env として書き出し
+#  - compose.prod.yaml で backend のみ起動 (DB は RDS)
 #  - nginx で / 静的配信 + /api/ をバックエンドにリバプロ
 
-# 1. パッケージ更新と必要ツール
+# 1. パッケージ
 dnf -y update
-dnf -y install docker git nginx tar
+dnf -y install docker git nginx tar postgresql16
 
-# 2. Docker 起動
+# 2. Docker
 systemctl enable --now docker
 usermod -aG docker ec2-user
 
@@ -20,7 +20,7 @@ DOCKER_CONFIG_DIR=/usr/libexec/docker/cli-plugins
 mkdir -p "$DOCKER_CONFIG_DIR"
 COMPOSE_VERSION="v2.29.7"
 ARCH="$(uname -m)"
-curl -sSL "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-linux-${ARCH}" \
+curl -sSL "https://github.com/docker/compose/releases/download/$${COMPOSE_VERSION}/docker-compose-linux-$${ARCH}" \
   -o "$DOCKER_CONFIG_DIR/docker-compose"
 chmod +x "$DOCKER_CONFIG_DIR/docker-compose"
 
@@ -31,29 +31,34 @@ git clone https://github.com/Hiroyuki-12/TaskManagement.git "$APP_DIR"
 # 5. GitHub Releases から成果物を取得
 RELEASE_BASE="https://github.com/Hiroyuki-12/TaskManagement/releases/latest/download"
 
-#   5-1. backend JAR
-curl -sSL --retry 5 --retry-delay 5 -L "${RELEASE_BASE}/app.jar" -o "$APP_DIR/backend/app.jar"
+curl -sSL --retry 5 --retry-delay 5 -L "$${RELEASE_BASE}/app.jar" -o "$APP_DIR/backend/app.jar"
 test -s "$APP_DIR/backend/app.jar"
 
-#   5-2. frontend tarball
-curl -sSL --retry 5 --retry-delay 5 -L "${RELEASE_BASE}/frontend-dist.tar.gz" -o /tmp/frontend-dist.tar.gz
+curl -sSL --retry 5 --retry-delay 5 -L "$${RELEASE_BASE}/frontend-dist.tar.gz" -o /tmp/frontend-dist.tar.gz
 test -s /tmp/frontend-dist.tar.gz
 rm -rf /var/www/html
 mkdir -p /var/www/html
 tar -xzf /tmp/frontend-dist.tar.gz -C /var/www/html --strip-components=1
 chown -R nginx:nginx /var/www/html
 
+# 6. RDS 接続情報を .env として書き出し (Terraform から渡される)
+cat > "$APP_DIR/.env" <<EOF
+SPRING_DATASOURCE_URL=jdbc:postgresql://${db_host}:${db_port}/${db_name}
+SPRING_DATASOURCE_USERNAME=${db_username}
+SPRING_DATASOURCE_PASSWORD=${db_password}
+EOF
+chmod 600 "$APP_DIR/.env"
+
 chown -R ec2-user:ec2-user "$APP_DIR"
 
-# 6. nginx 設定 (リポジトリの infra/nginx.conf を使用)
-#    AL2023 のデフォルト server (default.conf) を無効化し、taskmanagement.conf を配置
+# 7. nginx 設定
 rm -f /etc/nginx/conf.d/default.conf
 cp "$APP_DIR/infra/nginx.conf" /etc/nginx/conf.d/taskmanagement.conf
 nginx -t
 
-# 7. バックエンド起動
+# 8. backend 起動 (RDS に Flyway で自動マイグレーション)
 cd "$APP_DIR"
-docker compose -f compose.prod.yaml up -d --build
+docker compose --env-file .env -f compose.prod.yaml up -d --build
 
-# 8. nginx 起動
+# 9. nginx 起動
 systemctl enable --now nginx

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -20,3 +20,21 @@ variable "key_name" {
   type        = string
   default     = "taskmanagement-key"
 }
+
+variable "db_name" {
+  description = "RDS の DB 名"
+  type        = string
+  default     = "taskmanagement"
+}
+
+variable "db_username" {
+  description = "RDS の master ユーザー"
+  type        = string
+  default     = "task_user"
+}
+
+variable "db_password" {
+  description = "RDS の master パスワード (terraform.tfvars で指定、Git 管理外)"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
## Summary

Phase 2: PostgreSQL を EC2 同居 Docker から RDS マネージドへ。VPC を 2AZ 化し、private subnet 2 つに DB subnet group を作って RDS を配置。

## 変更点

- VPC: private subnet × 2 (10.0.11.0/24 / 10.0.12.0/24, AZ-a/c) + private RT
- RDS: db.t3.micro / PostgreSQL 16 / 20GB gp3 暗号化 / Single-AZ / publicly_accessible=false / skip_final_snapshot=true
- DB SG: 5432 ingress を EC2 SG からのみ許可
- variables.tf: db_password を sensitive で追加
- ec2.tf: user_data を templatefile() 化し RDS 接続情報を渡す
- user_data.sh → user_data.sh.tpl: .env を生成し docker compose --env-file で注入
- compose.prod.yaml: db サービス削除、env vars は外部参照

## Free tier

12 ヶ月無料 (db.t3.micro 750h, gp3 20GB, バックアップ 20GB)。期限後は約 \$15/月になるため要 destroy。

## Test plan

- [x] terraform fmt / validate / plan (9 add, 1 destroy)
- [ ] マージ後 terraform apply (RDS 作成は 5-7 分かかる)
- [ ] ブラウザで http://<dns>/ → カンバンが表示
- [ ] カード CRUD が動作 (RDS 永続化)
- [ ] 5432 直アクセス不可 (publicly_accessible=false)

Closes #41