### PR TITLE
docs: AWS インフラ構成のドキュメント整備 + Terraform 軽微修正 (#43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Trello 風のカンバン方式で個人のタスクを管理する Web アプ�
 - [技術スタック](#技術スタック)
 - [ローカル開発環境のセットアップ](#ローカル開発環境のセットアップ)
 - [ポート運用ルール](#ポート運用ルール)
+- [AWS デプロイ](#aws-デプロイ)
 - [ドキュメント一覧](#ドキュメント一覧)
 - [開発フロー](#開発フロー)
 
@@ -17,13 +18,16 @@ Trello 風のカンバン方式で個人のタスクを管理する Web アプ�
 
 ```
 TaskManagement/
-├── backend/        Spring Boot 4.0 + Java 25 (REST API)
-├── frontend/       React 19 + TypeScript + Vite + Tailwind CSS (SPA)
-├── compose.yaml    PostgreSQL 16 (ローカル開発用)
-├── docs/           設計・要件ドキュメント
-├── mocks/          モックデータ / 画面モック
-├── 要件定義書.md    要件定義のエントリポイント
-├── CLAUDE.md       Claude Code 用の運用ルール
+├── backend/             Spring Boot 4.0 + Java 25 (REST API)
+├── frontend/            React 19 + TypeScript + Vite + Tailwind CSS (SPA)
+├── infra/               Terraform: AWS デプロイ用 IaC
+├── compose.yaml         PostgreSQL 16 (ローカル開発用)
+├── compose.prod.yaml    本番想定の compose (EC2 / 同居検証)
+├── Makefile             ビルド & AWS デプロイのユーティリティ
+├── docs/                設計・要件・インフラ構成ドキュメント
+├── mocks/               モックデータ / 画面モック
+├── 要件定義書.md         要件定義のエントリポイント
+├── CLAUDE.md            Claude Code 用の運用ルール
 └── README.md
 ```
 
@@ -50,7 +54,12 @@ TaskManagement/
 
 ### データベース / インフラ
 
-- PostgreSQL 16 (Docker Compose)
+- PostgreSQL 16
+  - ローカル開発: Docker Compose
+  - AWS デプロイ時: RDS db.t3.micro
+- AWS デプロイ: EC2 t2.micro + Nginx + RDS (詳細は [docs/aws-architecture.md](docs/aws-architecture.md))
+- IaC: Terraform 1.6+ (`infra/`)
+- 成果物配布: GitHub Releases (`make release`)
 
 ## ローカル開発環境のセットアップ
 
@@ -116,6 +125,26 @@ npm run dev
 
 ポートが競合した場合は、`lsof -i :<port>` で占有プロセスを特定して停止し、本来のポートで起動し直す。詳細は [CLAUDE.md](CLAUDE.md#ポート運用ルール厳守) を参照。
 
+## AWS デプロイ
+
+学習目的で本アプリを AWS 上で稼働させるための IaC を `infra/` に用意している (Terraform)。
+**完全に AWS 無料枠 ($0 運用) 前提**で、EC2 + Nginx + RDS というシンプル構成。
+
+- 構成図 / 設計判断: [docs/aws-architecture.md](docs/aws-architecture.md)
+- 初回セットアップ・運用コマンド: [infra/README.md](infra/README.md)
+
+主な運用コマンド (リポジトリルートの `Makefile`):
+
+| コマンド | やること |
+|---|---|
+| `make release` | JAR + frontend dist を GitHub Releases に upload |
+| `make deploy` | terraform apply (初回) |
+| `make redeploy` | EC2 を作り直して新成果物を取得 |
+| `make ssh` / `make logs` / `make status` | EC2 操作・状態確認 |
+| `make destroy` | 全リソース削除 (課題提出後の必須作業) |
+
+> 12 ヶ月の無料枠を超えると EC2 / RDS が課金対象。**使わなくなったら必ず `make destroy`** すること。
+
 ## ドキュメント一覧
 
 | 種別 | ドキュメント |
@@ -128,6 +157,8 @@ npm run dev
 | データフロー / API | [docs/data-flow.md](docs/data-flow.md) |
 | 非機能要件 | [docs/non-functional-requirements.md](docs/non-functional-requirements.md) |
 | 技術スタック | [docs/tech-stack.md](docs/tech-stack.md) |
+| AWS インフラ構成 | [docs/aws-architecture.md](docs/aws-architecture.md) |
+| AWS デプロイ操作手順 | [infra/README.md](infra/README.md) |
 | 対象外機能（スコープ外） | [docs/out-of-scope.md](docs/out-of-scope.md) |
 | 運用ルール (Claude Code 用) | [CLAUDE.md](CLAUDE.md) |
 

--- a/docs/aws-architecture.md
+++ b/docs/aws-architecture.md
@@ -1,0 +1,140 @@
+# AWS インフラ構成
+
+TaskManagement を AWS にデプロイするためのインフラ構成と設計判断を記録する。
+個人利用・スクール課題向けに **AWS 無料枠 ($0 運用)** を前提とした最小構成。
+
+実際の Terraform コードは `infra/` 配下、操作手順は [`infra/README.md`](../infra/README.md) を参照。
+
+## 全体構成図
+
+```
+                                 [GitHub]
+                                    │
+                                    │ git clone / Releases (app.jar, frontend-dist.tar.gz)
+                                    ▼
+                                 [EC2 user_data]
+
+ユーザー ──HTTP/80──▶ ┌──────────────────────────────────────┐
+                    │ EC2 t2.micro (Public Subnet, AZ-a)    │
+                    │  ├─ Nginx (80)                        │
+                    │  │   ├─ /        → /var/www/html      │ React SPA
+                    │  │   └─ /api/*  → 127.0.0.1:8080      │
+                    │  └─ Spring Boot (8080) Docker         │ Java 25 + Boot 4
+                    │  EBS gp3 8GB (encrypted)              │
+                    └──────────────┬────────────────────────┘
+                                   │ VPC 内 Private DNS / 5432
+                                   ▼
+                    ┌──────────────────────────────────────┐
+                    │ RDS db.t3.micro (Private Subnets)    │
+                    │ PostgreSQL 16 / 20GB gp3 / Single-AZ │
+                    │ Subnet Group: AZ-a + AZ-c            │
+                    └──────────────────────────────────────┘
+```
+
+## ネットワーク設計
+
+VPC `10.0.0.0/16` 内に 1 つのパブリックサブネット (EC2 用) と、AZ をまたいだ 2 つのプライベートサブネット (RDS 用) を配置する。
+
+| サブネット | AZ | 用途 |
+|---|---|---|
+| Public | ap-northeast-1a | EC2 (Nginx + Spring Boot) |
+| Private A | ap-northeast-1a | RDS (主) |
+| Private C | ap-northeast-1c | RDS Subnet Group の冗長 AZ 要件を満たすためのみ |
+
+- Internet Gateway は Public サブネットからのみ到達可能 (default route)
+- Private サブネットには NAT Gateway を**置かない**(時間課金で無料枠外のため)
+- AZ は Terraform の `data "aws_availability_zones"` から動的取得
+
+### セキュリティグループ
+
+| SG | Ingress | Egress |
+|---|---|---|
+| EC2 SG | 22 / 80 を `var.my_ip/32` のみ | 全開放 (パッケージ取得・GitHub Releases 取得・RDS 接続のため) |
+| DB SG | 5432 を **EC2 SG からのみ** | 全開放 |
+
+8080 (Spring Boot) は SG で塞いでおり、Nginx 経由でしかバックエンドに到達できない。
+
+## 採用リソース一覧
+
+| AWS サービス | 用途 | 無料枠 |
+|---|---|---|
+| VPC / Subnet / IGW / Route Table | ネットワーク | 無料 |
+| Security Group | アクセス制御 | 無料 |
+| EC2 t2.micro | アプリ実行サーバー | 750h/月 (12ヶ月) |
+| EBS gp3 8GB (暗号化) | EC2 ルートディスク | 30GB/月 (12ヶ月) |
+| RDS db.t3.micro / PostgreSQL 16 | マネージド DB | 750h/月 (12ヶ月) |
+| RDS gp3 20GB (暗号化) + バックアップ | DB ストレージ | 各 20GB (12ヶ月) |
+| S3 (tfstate) | Terraform 状態管理 | 5GB (12ヶ月) |
+| DynamoDB (tflock) | tfstate ロック | 25GB (Always Free) |
+| データ転送 out | EC2 → ネット | 100GB/月 (Always Free) |
+
+### 採用していないもの (有料 / 無料枠外のため)
+
+- **NAT Gateway** (約 \$30/月) → プライベートサブネットからの outbound は無いので不要
+- **ALB / NLB** (約 \$16/月) → Nginx で代替
+- **Elastic IP** (関連付け中は無料、未使用時に課金) → DNS でアクセスする運用
+- **Route 53 / ACM (独自ドメイン)** → AWS 提供の `*.amazonaws.com` 名で済ます
+- **CloudFront / S3 静的配信** → フロントは EC2 上の Nginx で配信
+- **Multi-AZ RDS** (有料) → Single-AZ で十分
+
+## デプロイフロー
+
+```
+[ローカル Mac]
+  ./gradlew bootJar  ─▶ backend/app.jar
+  npm run build      ─▶ frontend/dist/  ─▶ frontend-dist.tar.gz
+                              │
+                              │ make release (gh release upload --clobber)
+                              ▼
+                       [GitHub Releases (tag: latest)]
+                              │
+                              │ make deploy / make redeploy
+                              │ → terraform apply
+                              ▼
+                       [EC2 user_data]
+                         curl で JAR / dist を取得 → 配置 → docker compose up
+                                                  → /etc/nginx/conf.d/ 配置 → systemctl start
+```
+
+ポイント:
+- t2.micro (1GB RAM) で Gradle / npm を回さない (OOM するため)
+- 重い処理はローカル Mac で行い、EC2 は **完成品を実行するだけ**
+- 成果物の配信に GitHub Releases を使うことで AWS 側の追加コストゼロ
+
+## tfstate 管理
+
+- **S3 backend** (`taskmanagement-tfstate-okkun`) に保管 (バージョニング・暗号化・パブリックアクセスブロック有効)
+- **DynamoDB** (`taskmanagement-tflock`) で同時編集ロック
+- backend を構成するための S3/DynamoDB は鶏卵問題回避のため **AWS CLI で初回手動作成** (Terraform 管理外)
+
+## 機密値の扱い
+
+| 値 | 保管場所 | コミット |
+|---|---|---|
+| AWS アクセスキー | `~/.aws/credentials` | しない |
+| EC2 SSH 秘密鍵 | `~/.ssh/taskmanagement-key.pem` (chmod 400) | しない (`*.pem` を gitignore) |
+| 自宅 IP (`my_ip`) | `infra/terraform.tfvars` | しない (`*.tfvars` を gitignore) |
+| RDS パスワード (`db_password`) | `infra/terraform.tfvars` | しない |
+| Terraform state | S3 (暗号化) | しない (`*.tfstate*` を gitignore) |
+
+`.tf` ファイル中では値を直接書かず、すべて `var.*` 経由で参照する。
+
+## 設計判断のメモ
+
+| トピック | 判断 | 理由 |
+|---|---|---|
+| DB の場所 | RDS 切り出し | スクール講座の構成に合わせる + マネージド運用学習 |
+| フロント配信 | EC2 上の Nginx | 構成シンプル、CloudFront/S3 不要、無料枠維持 |
+| ビルド環境 | ローカル Mac で固定 | t2.micro では重すぎる |
+| 成果物配布 | GitHub Releases | Public リポジトリなら無料・無制限 |
+| HTTPS | 未対応 (Phase 3) | 個人利用・my_ip 限定で運用するため優先度低 |
+| IAM Role | EC2 に未付与 | Phase 1 では不要、後で SSM Session Manager 化を検討 |
+
+## 12ヶ月後の課金注意
+
+EC2 / RDS / EBS の無料枠は **いずれも 12ヶ月限定**。期限後の概算:
+- EC2 t2.micro: 約 \$8/月
+- RDS db.t3.micro: 約 \$15/月
+- EBS gp3 + RDS ストレージ: 数 \$/月
+
+**課題提出後は速やかに `make destroy`** で全リソースを削除すること。

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -44,6 +44,19 @@
 | RDB | PostgreSQL | 16 (alpine) |
 | ローカル実行環境 | Docker Compose | — |
 
+## AWS デプロイ (個人利用 / 無料枠)
+
+| 分類 | 採用技術 | 備考 |
+|---|---|---|
+| IaC | Terraform | 1.6+ (S3 backend + DynamoDB ロック) |
+| コンピューティング | EC2 t2.micro (Amazon Linux 2023) | 12ヶ月無料 |
+| マネージド DB | RDS db.t3.micro / PostgreSQL 16 | 12ヶ月無料 |
+| リバースプロキシ / 静的配信 | Nginx (AL2023 dnf パッケージ) | EC2 同居 |
+| ランタイム (バックエンド) | Docker / Eclipse Temurin 25 JRE | コンテナで実行 |
+| 成果物配布 | GitHub Releases (タグ `latest`) | 公開リポ・無料・無制限 |
+
+詳細な構成・設計判断は [aws-architecture.md](aws-architecture.md)、操作手順は [`../infra/README.md`](../infra/README.md) を参照。
+
 ## 補足
 
 - Java は 2025 年 9 月リリースの最新 LTS である Java 25 を採用。Spring Boot は 2025 年 11 月 GA の最新メジャー 4.0.x を採用。

--- a/infra/README.md
+++ b/infra/README.md
@@ -2,39 +2,8 @@
 
 スクール課題向けの個人利用前提・**AWS 無料枠** で TaskManagement をデプロイするための Terraform 設定。
 
-## 構成 (Phase 2: RDS 切り出し済)
-
-```
-ユーザー ──HTTP/80──▶ ┌─────────────────────────────────┐
-                    │ EC2 t2.micro (Public Subnet, AZ-a)│
-                    │  ├─ Nginx (80)                    │
-                    │  │   ├─ /        → React 静的     │
-                    │  │   └─ /api/*  → :8080           │
-                    │  └─ Spring Boot (8080) Docker     │
-                    │  EBS gp3 8GB                      │
-                    └────────────┬─────────────────────┘
-                                 │ private DNS (5432)
-                                 ▼
-                    ┌─────────────────────────────────┐
-                    │ RDS db.t3.micro                 │
-                    │ PostgreSQL 16 / 20GB gp3        │
-                    │ (Private Subnets AZ-a, AZ-c)    │
-                    └─────────────────────────────────┘
-```
-
-| AWS リソース | 用途 | 課金 |
-|---|---|---|
-| VPC / Subnet / IGW / Route Table | ネットワーク | 無料 |
-| Security Group | 22 / 80 を `my_ip` のみ許可 | 無料 |
-| EC2 t2.micro | アプリ実行 | 750h/月 (12ヶ月) |
-| EBS gp3 8GB | EC2 ルートディスク | 30GB/月 (12ヶ月) |
-| RDS db.t3.micro | マネージド PostgreSQL | 750h/月 (12ヶ月) |
-| RDS gp3 20GB | DB ストレージ | 20GB (12ヶ月) |
-| S3 (tfstate) | Terraform 状態管理 | 5GB (12ヶ月) |
-| DynamoDB (tflock) | tfstate ロック | 25GB (Always Free) |
-| データ転送 out | EC2 → ネット | 100GB/月 (Always Free) |
-
-NAT Gateway / ALB / RDS / Route53 / Elastic IP は使わない (有料のため)。
+> **構成図・リソース選定理由・設計判断は [`../docs/aws-architecture.md`](../docs/aws-architecture.md) を参照。**
+> 本ファイルは初回セットアップ手順と日常運用コマンドに集中する。
 
 ## ディレクトリ
 

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -13,7 +13,7 @@ provider "aws" {
   default_tags {
     tags = {
       Project     = var.project
-      Environment = "phase1"
+      Environment = var.environment
       ManagedBy   = "terraform"
     }
   }

--- a/infra/rds.tf
+++ b/infra/rds.tf
@@ -52,8 +52,9 @@ resource "aws_db_instance" "main" {
   publicly_accessible    = false
   multi_az               = false
 
-  backup_retention_period    = 1
-  skip_final_snapshot        = true
+  backup_retention_period = 1
+  skip_final_snapshot     = true
+  # 個人課題で destroy しやすくするため false。本番運用では true 推奨。
   deletion_protection        = false
   auto_minor_version_upgrade = true
   apply_immediately          = true

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -10,6 +10,12 @@ variable "region" {
   default     = "ap-northeast-1"
 }
 
+variable "environment" {
+  description = "リソースの Environment タグ (dev / prod など)"
+  type        = string
+  default     = "prod"
+}
+
 variable "my_ip" {
   description = "SSH 接続を許可する自宅 IP (CIDR 形式 例: 203.0.113.10/32)。terraform.tfvars で設定し Git にコミットしないこと"
   type        = string


### PR DESCRIPTION
## Summary

- Terraform 品質チェック (新 skill terraform-quality を追加して実施) で挙がった軽微指摘を修正
- AWS 構成 (Phase 1〜2) を docs/aws-architecture.md に体系化
- README / tech-stack / infra/README を再構成し重複削除

## ドキュメントの責務分担

- docs/aws-architecture.md: 構成図・リソース選定理由・設計判断 (canonical)
- infra/README.md: 操作手順・トラブルシュート (operational)
- README.md / tech-stack.md: 概要 + 上記へのリンク

## Terraform 修正

- providers.tf の Environment タグを var.environment 参照化
- rds.tf の deletion_protection に本番運用向けコメント
- terraform fmt / validate / plan / apply (12 件タグ更新のみ) 通過

## Out of scope (skill ファイル)

terraform-quality skill は ~/.claude/skills/ 配下にローカル追加済み (本リポジトリ管理外)。

Closes #43